### PR TITLE
Apply text-balance to centered and right-aligned text

### DIFF
--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -58,7 +58,7 @@ When invoked, apply these opinionated constraints for building better interfaces
 
 ## Typography
 
-- MUST use `text-balance` for headings and `text-pretty` for body/paragraphs
+- MUST use `text-balance` for headings, centered text, and right-aligned text; use `text-pretty` for body/paragraphs
 - MUST use `tabular-nums` for data
 - SHOULD use `truncate` or `line-clamp` for dense UI
 - NEVER modify `letter-spacing` (`tracking-*`) unless explicitly requested


### PR DESCRIPTION
This is great! But I had to write in with my #1 UI pet peeve :) 

## Summary

- Extends the `text-balance` typography rule to include centered and right-aligned text, not just headings

This makes sense because `text-balance` evens out line lengths, which is particularly important for centered and right-aligned text where uneven lines are more visually noticeable than in left-aligned content.