### PR TITLE
add skill-review CI

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,14 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@14b47c8420ff9ac9a12c30ed4b89ce0e9d0355ae # main


### PR DESCRIPTION
hey @ibelick, following up on #9 and #10 (both merged, thanks!). adding a lightweight GitHub Action that auto-reviews any skill.md changed in a PR.

## what changes

**new `skill-review.yml`:**
- triggers on any PR that touches a SKILL.md file
- posts a review score as a PR comment
- minimal permissions (`pull-requests: write`, `contents: read`), SHA-pinned action

## how it fits with your existing CI

| workflow | trigger | purpose |
|---|---|---|
| `release.yml` | existing | release automation |
| `skill-review.yml` (new) | PR | review scores on skill.md changes |

no overlap - skill-review only runs on PRs touching SKILL.md files. no config needed, no tokens needed.

this means that it gives you and your contributors an instant quality signal on every skill.md change before you have to review yourself.