### PR TITLE
Add Compose Expert skill

### DIFF
--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -39,7 +39,8 @@ export type TopicSlug =
   | "react-native"
   | "threejs"
   | "remotion"
-  | "swiftui";
+  | "swiftui"
+  | "compose";
 
 type RegistrySourceSkill = Omit<
   RegistrySkill,
@@ -345,6 +346,25 @@ const registrySource: RegistrySourceSkill[] = [
     topics: ["react-native", "performance", "frontend"],
     description:
       "React Native performance optimization guidelines for FPS, TTI, bundle size, memory leaks, re-renders, and animations.",
+  },
+  {
+    slug: "compose-expert",
+    user: "aldefy",
+    repo: "compose-skill",
+    rawUrl:
+      "https://raw.githubusercontent.com/aldefy/compose-skill/master/skills/compose-expert/SKILL.md",
+    githubUrl:
+      "https://github.com/aldefy/compose-skill/blob/master/skills/compose-expert/SKILL.md",
+    name: "compose-expert",
+    topics: [
+      "compose",
+      "frontend",
+      "architecture",
+      "performance",
+      "accessibility",
+    ],
+    description:
+      "Jetpack Compose and Compose Multiplatform guidance backed by AndroidX source references, covering state, recomposition, modifiers, navigation, accessibility, design-to-code, and production crash patterns.",
   },
   {
     slug: "threejs-animation",

--- a/src/data/topics.ts
+++ b/src/data/topics.ts
@@ -141,6 +141,13 @@ export const topics: Topic[] = [
     isDesignCore: false,
   },
   {
+    slug: "compose",
+    label: "Compose",
+    description:
+      "Jetpack Compose and Compose Multiplatform UI patterns for Android and Kotlin interfaces.",
+    isDesignCore: false,
+  },
+  {
     slug: "threejs",
     label: "Three.js",
     description:
@@ -203,6 +210,7 @@ export const relatedTopicSlugs: Record<TopicSlug, TopicSlug[]> = {
   nuxt: ["vue", "frontend", "performance", "tooling"],
   vue: ["nuxt", "frontend", "tooling", "performance"],
   "react-native": ["frontend", "performance", "interaction", "testing"],
+  compose: ["frontend", "architecture", "performance", "accessibility"],
   threejs: ["3d", "visual", "interaction", "performance"],
   remotion: ["video", "motion", "frontend", "visual"],
   swiftui: ["interaction", "systems", "performance", "frontend"],


### PR DESCRIPTION
Adds `compose-expert`, a Jetpack Compose / Compose Multiplatform agent skill by aldefy.\n\nThe skill helps agents produce better Compose UI code using AndroidX and Compose Multiplatform source references. It covers state, recomposition, modifiers, navigation, accessibility, design-to-code, performance, crash patterns, and multiplatform UI guidance.\n\nThis also adds a `compose` topic so Compose skills are discoverable alongside React Native and SwiftUI.\n\nValidation:\n- `npm run build`\n- `npx prettier --check src/data/registry.ts src/data/topics.ts`