### PR TITLE
feat: add product-ui-design to registry

### DIFF
--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -1406,6 +1406,19 @@ const registrySource: RegistrySourceSkill[] = [
     description:
       "Production-ready CSS transition patterns for web apps, with drop-in snippets for cards, modals, dropdowns, panels, and page transitions.",
   },
+  {
+    slug: "product-ui-design",
+    user: "kuras3",
+    repo: "product-ui-design",
+    rawUrl:
+      "https://raw.githubusercontent.com/kuras3/product-ui-design/main/SKILL.md",
+    githubUrl:
+      "https://github.com/kuras3/product-ui-design/blob/main/SKILL.md",
+    name: "product-ui-design",
+    topics: ["craft", "systems", "taste"],
+    description:
+      "Restrained product UI for dashboards, SaaS, settings, and admin surfaces — with output-time hard-checks against common AI tells and observation-anchored primitives.",
+  },
 ];
 
 const buildInitialPathSlug = (entry: RegistrySourceSkill) => {


### PR DESCRIPTION
Adds **product-ui-design** to the registry.

**Scope:** dashboards, SaaS, settings, admin surfaces — the restrained register. The skill anchors values to observation of real shipped products (Linear / Stripe / Notion / Apple reference DNA profiles), provides concrete primitives (semantic tokens, button norms, table/form/status defaults), and includes an output-time hard-check list to catch common AI tells before they ship. An optional no-dependency `scan-tells.py` provides a mechanical gate.

- Repo: https://github.com/kuras3/product-ui-design (MIT, v0.1.0)
- SKILL.md: https://github.com/kuras3/product-ui-design/blob/main/SKILL.md
- Topics: `craft`, `systems`, `taste`

Happy to adjust the description, slug, or topics if any of them don't fit the catalog's conventions — just let me know.
