### PR TITLE
feat: add unslop skills to registry

### DIFF
--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -1407,17 +1407,43 @@ const registrySource: RegistrySourceSkill[] = [
       "Production-ready CSS transition patterns for web apps, with drop-in snippets for cards, modals, dropdowns, panels, and page transitions.",
   },
   {
-    slug: "unslop",
+    slug: "unslop-audit",
     user: "aahil62",
     repo: "unslop",
     rawUrl:
       "https://raw.githubusercontent.com/aahil62/unslop/main/skills/audit/SKILL.md",
     githubUrl:
       "https://github.com/aahil62/unslop/blob/main/skills/audit/SKILL.md",
-    name: "unslop",
-    topics: ["taste", "systems", "accessibility"],
+    name: "unslop-audit",
+    topics: ["accessibility", "systems", "craft"],
     description:
-      "Rescues an existing React + Tailwind site from the generic-AI look: scores it against an evidence-based checklist, synthesizes a custom design lane from a taste interview, then re-themes it pass-by-pass with build and screenshot verification.",
+      "Stage 1 of Unslop (audit → interview → retheme): scores an existing React + Tailwind site against an evidence-based anti-slop checklist — screenshots, WCAG contrast checks, and a static scan — and writes a scored DESIGN-AUDIT.md. Read-only.",
+  },
+  {
+    slug: "unslop-interview",
+    user: "aahil62",
+    repo: "unslop",
+    rawUrl:
+      "https://raw.githubusercontent.com/aahil62/unslop/main/skills/interview/SKILL.md",
+    githubUrl:
+      "https://github.com/aahil62/unslop/blob/main/skills/interview/SKILL.md",
+    name: "unslop-interview",
+    topics: ["taste", "color", "typography"],
+    description:
+      "Stage 2 of Unslop: interviews you about brand, audience, and taste, then synthesizes a one-off design lane — palette, type pairing, motion, signature moment — with no preset menu and no two lanes alike. Outputs an approved LANE.md.",
+  },
+  {
+    slug: "unslop-retheme",
+    user: "aahil62",
+    repo: "unslop",
+    rawUrl:
+      "https://raw.githubusercontent.com/aahil62/unslop/main/skills/retheme/SKILL.md",
+    githubUrl:
+      "https://github.com/aahil62/unslop/blob/main/skills/retheme/SKILL.md",
+    name: "unslop-retheme",
+    topics: ["systems", "motion", "frontend"],
+    description:
+      "Stage 3 of Unslop: applies an approved design lane to a React + Tailwind site pass by pass — tokens, typography, sections, then states and motion — with a build-and-screenshot check after every pass.",
   },
 ];
 

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -1443,7 +1443,7 @@ const registrySource: RegistrySourceSkill[] = [
     name: "unslop-retheme",
     topics: ["systems", "motion", "frontend"],
     description:
-      "Stage 3 of Unslop: applies an approved design lane to a React + Tailwind site pass by pass — tokens, typography, sections, then states and motion — with a build-and-screenshot check after every pass.",
+      "Stage 3 of Unslop: applies an approved design lane to a React + Tailwind site pass by pass — tokens, typography, sections, then states and motion — with a build-and-screenshot check after every pass, ending in a client-ready before/after report.",
   },
 ];
 

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -1406,6 +1406,19 @@ const registrySource: RegistrySourceSkill[] = [
     description:
       "Production-ready CSS transition patterns for web apps, with drop-in snippets for cards, modals, dropdowns, panels, and page transitions.",
   },
+  {
+    slug: "unslop",
+    user: "aahil62",
+    repo: "unslop",
+    rawUrl:
+      "https://raw.githubusercontent.com/aahil62/unslop/main/skills/audit/SKILL.md",
+    githubUrl:
+      "https://github.com/aahil62/unslop/blob/main/skills/audit/SKILL.md",
+    name: "unslop",
+    topics: ["taste", "systems", "accessibility"],
+    description:
+      "Rescues an existing React + Tailwind site from the generic-AI look: scores it against an evidence-based checklist, synthesizes a custom design lane from a taste interview, then re-themes it pass-by-pass with build and screenshot verification.",
+  },
 ];
 
 const buildInitialPathSlug = (entry: RegistrySourceSkill) => {


### PR DESCRIPTION
Adds **unslop**'s three skills to the registry — one entry per stage.

Most design skills generate new UI or lint one dimension of it. Unslop does neither — it's a 3-stage pipeline for **sites you've already shipped**: score the AI-slop with evidence (screenshots, WCAG contrast, static scan), synthesize a one-off design lane from a taste interview (no preset menu — no two lanes alike), then re-theme pass-by-pass with a build-and-screenshot gate after every change. All three ship together as one Claude Code plugin.

- Repo: https://github.com/aahil62/unslop (MIT, v0.2.0)
- `unslop-audit` — https://github.com/aahil62/unslop/blob/main/skills/audit/SKILL.md — `accessibility`, `systems`, `craft`
- `unslop-interview` — https://github.com/aahil62/unslop/blob/main/skills/interview/SKILL.md — `taste`, `color`, `typography`
- `unslop-retheme` — https://github.com/aahil62/unslop/blob/main/skills/retheme/SKILL.md — `systems`, `motion`, `frontend`

Happy to adjust descriptions, slugs, or topics if any of them don't fit the catalog's conventions — just let me know.
