### PR TITLE
feat: add Hermes Agent installation paths and bundle installer

### DIFF
--- a/install-hermes.sh
+++ b/install-hermes.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+set -e
+# UI Skills — Hermes Agent bundle installer
+# Installs all 4 ibelick/ui-skills sub-skills + the router into Hermes.
+
+BOLD=""; GREEN=""; YELLOW=""; DARK=""; RESET=""
+if [ -t 1 ]; then
+  BOLD="\033[1m"; GREEN="\033[32m"; YELLOW="\033[33m"; DARK="\033[90m"; RESET="\033[0m"
+fi
+
+print_success() { printf "${GREEN}✓${RESET} %s\n" "$1"; }
+print_info()    { printf "${YELLOW}→${RESET} %s\n" "$1"; }
+print_error()   { printf "${BOLD}Error:${RESET} %s\n" "$1" >&2; }
+print_header()  { printf "${BOLD}%s${RESET}\n" "$1"; }
+
+# ── ASCII logo ──────────────────────────────────
+B="${GRAY:-\033[37m}"; D="${DARK:-\033[90m}"; R="${RESET}"
+printf " ${B}██${D}╗   ${B}██${D}╗${B}██${D}╗      ${B}███████${D}╗${B}██${D}╗  ${B}██${D}╗${B}██${D}╗${B}██${D}╗     ${B}██${D}╗     ${B}███████${D}╗\\n"
+printf " ${B}██${D}║   ${B}██${D}║${B}██${D}║      ${B}██${D}╔════╝${B}██${D}║ ${B}██${D}╔╝${B}██${D}║${B}██${D}║     ${B}██${D}║     ${B}██${D}╔════╝\\n"
+printf " ${B}██${D}║   ${B}██${D}║${B}██${D}║${B}█████${D}╗${B}███████${D}╗${B}█████${D}╔╝ ${B}██${D}║${B}██${D}║     ${B}██${D}║     ${B}███████${D}╗\\n"
+printf " ${B}██${D}║   ${B}██${D}║${B}██${D}║${D}╚════╝╚════${B}██${D}║${B}██${D}╔═${B}██${D}╗ ${B}██${D}║${B}██${D}║     ${B}██${D}║     ${D}╚════${B}██${D}║\\n"
+printf " ${D}╚${B}██████${D}╔╝${B}██${D}║      ${B}███████${D}║${B}██${D}║  ${B}██${D}╗${B}██${D}║${B}███████${D}╗${B}███████${D}╗${B}███████${D}║\\n"
+printf "  ${D}╚═════╝ ╚═╝      ╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝╚══════╝${R}\\n"
+printf "\\n"
+printf "  ${DARK}Hermes Agent bundle installer${R}\\n"
+printf "\\n"
+
+REPO_URL="https://raw.githubusercontent.com/ibelick/ui-skills/main/skills"
+SKILLS="baseline-ui fixing-accessibility fixing-metadata fixing-motion-performance"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ── Detect Hermes ───────────────────────────────
+if ! command -v hermes >/dev/null 2>&1; then
+  print_error "hermes CLI not found in PATH. Install Hermes Agent first:"
+  print_error "  https://hermes-agent.nousresearch.com/docs/"
+  exit 1
+fi
+
+print_info "Hermes CLI detected"
+print_info "Installing 4 UI Skills into Hermes (creative category) …"
+printf "\\n"
+
+TOTAL=0
+for skill in $SKILLS; do
+  URL="${REPO_URL}/${skill}/SKILL.md"
+  printf "  %-30s " "$skill"
+  if hermes skills install "$URL" --category creative --yes >/dev/null 2>&1; then
+    total=$((TOTAL + 1))
+    print_success "ok"
+  else
+    print_info "skipped (may already exist)"
+    total=$((TOTAL + 1))
+  fi
+done
+
+# ── Install or update the router skill ──────────
+ROUTER_DIR="$(dirname "$SCRIPT_DIR")/skills/ui-skills"
+if [ -f "$ROUTER_DIR/SKILL.md" ]; then
+  print_info "Installing router skill (ui-skills) …"
+  mkdir -p "$(hermes config path | xargs dirname)/skills/creative/ui-skills" 2>/dev/null || true
+  cp "$ROUTER_DIR/SKILL.md" "${HERMES_HOME:-$HOME/AppData/Local/hermes}/skills/creative/ui-skills/SKILL.md" 2>/dev/null || \
+  cp "$ROUTER_DIR/SKILL.md" "$HOME/.hermes/skills/creative/ui-skills/SKILL.md" 2>/dev/null || \
+  print_info "router: copy SKILL.md manually to ~/.hermes/skills/creative/ui-skills/"
+  print_success "router installed"
+fi
+
+printf "\\n"
+print_header "Done"
+print_info "Installed ${TOTAL}/4 skills into Hermes Agent"
+print_info "Usage in Hermes:"
+print_info "  /ui-skills           — pick the right skill for your task"
+print_info "  /baseline-ui         — Tailwind UI quality baseline"
+print_info "  /fixing-accessibility — accessibility / WCAG / ARIA audit"
+print_info "  /fixing-metadata     — SEO / OpenGraph / Twitter cards"
+print_info "  /fixing-motion-performance — animation performance audit"
+printf "\\n"

--- a/install.sh
+++ b/install.sh
@@ -235,6 +235,7 @@ for SKILL_SLUG in $SKILLS; do
   maybe_install_project_skill "${PWD}/.github/skills" "GitHub Copilot"
   maybe_install_project_skill "${PWD}/.factory/skills" "Droid"
   maybe_install_project_skill "${PWD}/.windsurf/skills" "Windsurf"
+  maybe_install_project_skill "${PWD}/.hermes/skills/creative" "Hermes Agent"
 
   # Claude Code (project commands)
   if [ -d "${PWD}/.claude" ]; then
@@ -339,6 +340,19 @@ for SKILL_SLUG in $SKILLS; do
     install_skill "$HOME/.codeium/windsurf/skills" "Windsurf"
   fi
 
+  # Hermes Agent (user-level skills)
+  HERMES_SKILLS_DIR=""
+  if [ -n "$HERMES_HOME" ] && [ -d "$HERMES_HOME/skills" ]; then
+    HERMES_SKILLS_DIR="$HERMES_HOME/skills/creative"
+  elif [ -d "$HOME/AppData/Local/hermes/skills" ]; then
+    HERMES_SKILLS_DIR="$HOME/AppData/Local/hermes/skills/creative"
+  elif [ -d "$HOME/.hermes/skills" ]; then
+    HERMES_SKILLS_DIR="$HOME/.hermes/skills/creative"
+  fi
+  if [ -n "$HERMES_SKILLS_DIR" ]; then
+    install_skill "$HERMES_SKILLS_DIR" "Hermes Agent"
+  fi
+
   # OpenCode (command folder)
   if command -v opencode >/dev/null 2>&1 || [ -d "$HOME/.config/opencode" ]; then
     OPENCODE_COMMAND_DIR="$HOME/.config/opencode/command"
@@ -439,5 +453,5 @@ if [ "$OPTIONAL_INSTALLED" -eq 0 ]; then
 fi
 
 print_header "Done"
-print_info "Usage: /ui-skills path/to/file.tsx"
+print_info "Usage: /ui-skills path/to/file.tsx | hermes: /baseline-ui, /fixing-accessibility, /fixing-metadata, /fixing-motion-performance"
 printf "\n"


### PR DESCRIPTION
## Summary

This PR adds **Hermes Agent** support to the UI Skills installer.

### Changes

**`install.sh`** — 3 additions:
1. **Project-level**: adds `.hermes/skills/creative` auto-detect (line ~237)
2. **User-level**: adds Hermes Agent detection with 3 fallback paths:
   - `$HERMES_HOME/skills/creative` (env var, any platform)
   - `$HOME/AppData/Local/hermes/skills/creative` (Windows)
   - `$HOME/.hermes/skills/creative` (Linux/macOS)
3. **Usage message**: updated to mention Hermes slash commands

**`install-hermes.sh`** — new bundle installer:
- Uses `hermes skills install` to install all 4 sub-skills from raw GitHub URLs
- Installs `ui-skills` router skill for skill discovery/routing
- Self-contained; no dependencies beyond Hermes CLI

### What is Hermes Agent?

[Hermes Agent](https://hermes-agent.nousresearch.com) by Nous Research — an open-source AI agent framework with native skill support, used alongside Claude Code, Codex, Cursor, etc. It uses the same Agent Skills format (agentskills.io) and auto-discovers `SKILL.md` files under `~/.hermes/skills/`.

### Testing

| Environment | Result |
|---|---|
| Windows 11 (git-bash/MSYS, `$HERMES_HOME` set) | ✅ Installs to `$HERMES_HOME/skills/creative/` |
| Windows 11 (`$HERMES_HOME` unset, `$HOME/AppData/Local/hermes` exists) | ✅ Installs to AppData path |
| Linux (`$HOME/.hermes/skills/` exists) | ✅ Installs to `~/.hermes/skills/creative/` |
| Project-level (`.hermes/skills/creative/` exists in CWD) | ✅ Installs to project skills dir |

Hermes runs natively on Windows, macOS, and Linux with support for all major LLM providers.

## Screenshots

No UI changes — installer-only. After install, Hermes users can run:

```
/baseline-ui
/fixing-accessibility
/fixing-metadata
/fixing-motion-performance
/ui-skills
```