### PR TITLE
feat: add ui-skills-root, update cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Skills for Design Engineers
 
 More on [ui-skills.com](http://ui-skills.com/)
 
+CLI: `npx ui-skills` for registry access. Use `npx ui-skills start` to print the routing skill.
+
 ## License
 
 Licensed under the [MIT license](https://github.com/ibelick/ui-skills/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,19 @@ Skills for Design Engineers
 
 More on [ui-skills.com](http://ui-skills.com/)
 
-CLI: `npx ui-skills` for registry access. Use `npx ui-skills start` to print the routing skill.
+Agents should run `npx ui-skills start` first for UI task prompts.
+
+## CLI
+
+```bash
+npx ui-skills
+npx ui-skills start
+npx ui-skills categories
+npx ui-skills list --category motion
+npx ui-skills get baseline-ui
+```
+
+Example prompt: `Refine the motion on this dialog so the entrance feels smoother and the exit feels less abrupt.` Agents should run `npx ui-skills start` first, then use `categories`, `list`, and `get`.
 
 ## License
 

--- a/bin/ui-skills
+++ b/bin/ui-skills
@@ -12,40 +12,6 @@ if command -v readlink >/dev/null 2>&1; then
   done
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)"
-INSTALLER="$SCRIPT_DIR/install.sh"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
 
-if [ ! -f "$INSTALLER" ]; then
-  echo "Error: installer script not found at $INSTALLER" >&2
-  exit 1
-fi
-
-COMMAND="${1:-add}"
-
-case "$COMMAND" in
-  add)
-    shift || true
-    UI_SKILLS_COMMAND="ui-skills" UI_SKILLS_SUBCOMMAND="add" sh "$INSTALLER" "$@"
-    ;;
-  install)
-    shift || true
-    UI_SKILLS_COMMAND="ui-skills" UI_SKILLS_SUBCOMMAND="install" sh "$INSTALLER" "$@"
-    ;;
-  --help|-h|help)
-    cat <<'EOF'
-Usage:
-  ui-skills add [--all|<skill>|"<skill1 skill2 ...>"]
-  ui-skills install [--all|<skill>|"<skill1 skill2 ...>"]
-
-Examples:
-  ui-skills add --all
-  ui-skills add baseline-ui
-  ui-skills add "frontend-design ui-ux-pro-max"
-EOF
-    ;;
-  *)
-    echo "Unknown subcommand: $COMMAND" >&2
-    echo "Run 'ui-skills --help' for usage." >&2
-    exit 1
-    ;;
-esac
+exec node --experimental-strip-types "$SCRIPT_DIR/ui-skills.ts" "$@"

--- a/bin/ui-skills.ts
+++ b/bin/ui-skills.ts
@@ -1,0 +1,230 @@
+#!/usr/bin/env -S node --experimental-strip-types
+
+import { readFile } from "node:fs/promises";
+import { registry } from "../src/data/registry.ts";
+import { skills } from "../src/data/skills.ts";
+import { topics, topicBySlug, type Topic } from "../src/data/topics.ts";
+
+const argv = process.argv.slice(2);
+
+const START_SKILL_URL = new URL("../skills/ui-skills-root/SKILL.md", import.meta.url);
+
+const BANNER = [
+  " ██╗   ██╗██╗      ███████╗██╗  ██╗██╗██╗     ██╗     ███████╗",
+  " ██║   ██║██║      ██╔════╝██║ ██╔╝██║██║     ██║     ██╔════╝",
+  " ██║   ██║██║█████╗███████╗█████╔╝ ██║██║     ██║     ███████╗",
+  " ██║   ██║██║╚════╝╚════██║██╔═██╗ ██║██║     ██║     ╚════██║",
+  " ╚██████╔╝██║      ███████║██║  ██╗██║███████╗███████╗███████║",
+  "  ╚═════╝ ╚═╝      ╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝╚══════╝",
+].join("\n");
+
+const HELP = [
+  BANNER,
+  "",
+  "Skills for Design Engineers",
+  "",
+  "Usage:",
+  "  ui-skills [command]",
+  "",
+  "Commands:",
+  "  start                     Print the routing skill",
+  "  categories                List categories",
+  "  list [--category <topic>] List skills",
+  "  get <slug>                Print full skill markdown",
+  "",
+  "Examples:",
+  "  ui-skills start",
+  "  ui-skills list --category motion",
+  "  ui-skills get baseline-ui",
+].join("\n");
+
+const normalize = (value: string) => value.trim().toLowerCase();
+
+const print = (value: string) => {
+  process.stdout.write(`${value}\n`);
+};
+
+const failExtraArgs = (command: string) => {
+  fail(`Too many arguments for ${command}`, 1);
+};
+
+const readLocalSkillMarkdown = async (slug: string) => {
+  try {
+    return await readFile(new URL(`../skills/${slug}/SKILL.md`, import.meta.url), "utf8");
+  } catch {
+    return null;
+  }
+};
+
+const printSkillMarkdown = async () => {
+  process.stdout.write(await readFile(START_SKILL_URL, "utf8"));
+};
+
+const fail = (message: string, code = 1) => {
+  process.stderr.write(`${message}\n`);
+  process.exitCode = code;
+};
+
+const formatTopic = (slug: Topic["slug"]) => {
+  return slug;
+};
+
+const formatSkill = (skill: (typeof skills)[number]) => {
+  const categories = (skill.topics ?? []).join(", ");
+  const description = (skill.description ?? "").replace(/\s+/g, " ").trim();
+  return `${skill.pathSlug} — ${categories} — ${description}`;
+};
+
+const resolveSkillCandidates = (input: string) => {
+  const normalizedInput = normalize(input);
+  const exactPath = registry.find(
+    (entry) => normalize(entry.pathSlug) === normalizedInput,
+  );
+  if (exactPath) {
+    return [exactPath];
+  }
+
+  const bySlug = registry.filter(
+    (entry) => normalize(entry.slug) === normalizedInput,
+  );
+  return bySlug;
+};
+
+const printList = (category?: string) => {
+  const normalizedCategory = category ? normalize(category) : undefined;
+  const filtered = category
+    ? skills.filter((skill) =>
+        skill.topics?.includes(normalizedCategory as Topic["slug"]),
+      )
+    : skills;
+
+  if (category && !topicBySlug.has(normalizedCategory as Topic["slug"])) {
+    fail(`Unknown category: ${category}`, 3);
+    return;
+  }
+
+  if (category && filtered.length === 0) {
+    fail(`No skills found for category: ${category}`, 3);
+    return;
+  }
+
+  print(filtered.map(formatSkill).join("\n"));
+};
+
+const printGet = async (input: string) => {
+  const candidates = resolveSkillCandidates(input);
+
+  if (candidates.length === 0) {
+    fail(`Skill not found: ${input}`, 3);
+    return;
+  }
+
+  if (candidates.length > 1) {
+    process.stderr.write(`Ambiguous skill slug: ${input}\n`);
+    process.stderr.write("Candidates:\n");
+    for (const candidate of candidates) {
+      process.stderr.write(`- ${candidate.pathSlug}\n`);
+    }
+    process.exitCode = 3;
+    return;
+  }
+
+  const skill = candidates[0];
+  try {
+    const localMarkdown = await readLocalSkillMarkdown(skill.slug);
+    if (localMarkdown) {
+      process.stdout.write(localMarkdown);
+      process.stdout.write("\n");
+      return;
+    }
+
+    const response = await fetch(skill.rawUrl);
+    if (!response.ok) {
+      fail(`Failed to fetch ${skill.rawUrl} (${response.status} ${response.statusText})`, 4);
+      return;
+    }
+
+    process.stdout.write(await response.text());
+    process.stdout.write("\n");
+  } catch (error) {
+    fail(`Error fetching skill content: ${error instanceof Error ? error.message : String(error)}`, 4);
+  }
+};
+
+const main = async () => {
+  const [command = ""] = argv;
+
+  if (!command || command === "--help" || command === "-h" || command === "help") {
+    print(HELP);
+    return;
+  }
+
+  if (command === "start") {
+    if (argv.length > 1) {
+      failExtraArgs("start");
+      return;
+    }
+
+    await printSkillMarkdown();
+    return;
+  }
+
+  if (command === "categories") {
+    if (argv.length > 1) {
+      failExtraArgs("categories");
+      return;
+    }
+
+    print(topics.map((topic) => formatTopic(topic.slug)).join("\n"));
+    return;
+  }
+
+  if (command === "list") {
+    const args = argv.slice(1);
+
+    if (args.length === 0) {
+      printList();
+      return;
+    }
+
+    if (args.length === 1 && args[0] === "--category") {
+      fail("Missing value for --category", 1);
+      return;
+    }
+
+    if (args.length === 2 && args[0] === "--category") {
+      printList(args[1]);
+      return;
+    }
+
+    if (args.length > 0) {
+      failExtraArgs("list");
+      return;
+    }
+
+    printList();
+    return;
+  }
+
+  if (command === "get") {
+    const args = argv.slice(1);
+
+    if (args.length > 1) {
+      failExtraArgs("get");
+      return;
+    }
+
+    const target = args[0];
+    if (!target) {
+      fail("Missing skill slug", 1);
+      return;
+    }
+
+    await printGet(target);
+    return;
+  }
+
+  fail(`Unknown command: ${command}`, 2);
+};
+
+await main();

--- a/install.sh
+++ b/install.sh
@@ -59,8 +59,8 @@ print_error() {
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-DEFAULT_SKILL="baseline-ui"
-ALL_SKILLS="baseline-ui fixing-accessibility fixing-metadata fixing-motion-performance frontend-design"
+DEFAULT_SKILL="ui-skills-root"
+ALL_SKILLS="ui-skills-root baseline-ui fixing-accessibility fixing-metadata fixing-motion-performance frontend-design"
 UI_SKILLS_BASE_URL="${UI_SKILLS_BASE_URL:-https://ui-skills.com}"
 SKILL_URL_BASE="${UI_SKILLS_BASE_URL%/}/skills"
 REGISTRY_URL="${UI_SKILLS_REGISTRY_URL:-${SKILL_URL_BASE}/registry.txt}"
@@ -439,5 +439,5 @@ if [ "$OPTIONAL_INSTALLED" -eq 0 ]; then
 fi
 
 print_header "Done"
-print_info "Usage: /ui-skills path/to/file.tsx"
+print_info "Usage: /ui-skills-root <task>"
 printf "\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui-skills",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui-skills",
-      "version": "0.1.6",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@astrojs/react": "^4.4.2",
@@ -30,6 +30,7 @@
         "@astrojs/check": "^0.9.9",
         "@tailwindcss/typography": "^0.5.19",
         "@types/marked": "^5.0.2",
+        "@types/node": "^25.9.3",
         "prettier": "^3.3.3",
         "prettier-plugin-astro": "^0.14.1",
         "prettier-plugin-tailwindcss": "^0.6.8",
@@ -2558,6 +2559,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/react": {
@@ -6695,6 +6706,13 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-skills",
   "type": "module",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "license": "MIT",
   "bin": {
     "ui-skills": "bin/ui-skills"
@@ -33,6 +33,7 @@
     "@astrojs/check": "^0.9.9",
     "@tailwindcss/typography": "^0.5.19",
     "@types/marked": "^5.0.2",
+    "@types/node": "^25.9.3",
     "prettier": "^3.3.3",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "^0.6.8",

--- a/skills/baseline-ui/SKILL.md
+++ b/skills/baseline-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: baseline-ui
-description: Validates animation durations, enforces typography scale, checks component accessibility, and prevents layout anti-patterns in Tailwind CSS projects. Use when building UI components, reviewing CSS utilities, styling React views, or enforcing design consistency.
+description: Quickly deslop UI code by fixing spacing, hierarchy, typography, and small layout issues. Use when the interface needs a fast cleanup or polish pass.
 ---
 
 # Baseline UI

--- a/skills/ui-skills-root/SKILL.md
+++ b/skills/ui-skills-root/SKILL.md
@@ -1,62 +1,53 @@
 ---
 name: ui-skills-root
-description: Use when the user needs UI help and you must route by topic, stack, and intent to the smallest useful set of UI skills.
+description: Use before UI-related work to select the smallest useful UI Skills context through the ui-skills CLI.
+license: MIT
+metadata:
+  author: ibelick
+  version: "1.0.0"
 ---
 
 # UI Skills Root
 
-You are the router for UI Skills.
+You are the routing layer for UI Skills.
 
-Do not solve the request directly unless no skill fits.
-The registry contains both local `ibelick` skills and hosted skills from `ui-skills.com`; treat them as one routing pool.
+Before editing UI, use `ui-skills start`, then route by category with the CLI. Select first. Implement after.
 
-## Rules
+## Protocol
 
-- Route by topic first, then repo stack, then specificity.
-- Prefer the smallest useful set of skills.
-- Default to 1 skill.
-- Never return more than 3 skills.
-- Prefer task-specific skills over broad polish skills.
-- Prefer framework-specific skills when the stack is obvious.
-- Return `no skill needed` if the request is not UI-related.
-- If confidence is low, ask one short clarifying question.
+1. decide if the task is UI-related
+2. if not, return `no skill needed`
+3. identify the likely category
+4. inspect that category with the CLI
+5. select the smallest useful skill set
+6. load only selected skill(s)
+7. implement using that context
 
-## Routing order
+## CLI
 
-1. Detect the user's intent.
-2. Detect the repo stack.
-3. Map the request to one or more topics.
-4. Pick the best matching skill for those topics.
-5. Load only that skill, or up to 3 if the task is broad.
+```bash
+npx ui-skills start
+npx ui-skills categories
+npx ui-skills list --category <category>
+npx ui-skills get <slug>
+```
 
-## Topic examples
+## Selection Rules
 
-- `accessibility` -> `fixing-accessibility`, `wcag-audit-patterns`, `audit-and-fix`
-- `motion` or `performance` -> `fixing-motion-performance`, `mastering-animate-presence`, `to-spring-or-not-to-spring`
-- `visual` or `craft` or quick cleanup -> `baseline-ui`, `frontend-design`, `emil-design-eng`, `make-interfaces-feel-better`
-- `baseline-ui` is the quick deslop / polish path for fast cleanup, spacing, hierarchy, and small UI fixes.
-- `systems` or `tooling` -> `shadcn`, `antfu`, `pnpm`, `vite`
-- `nextjs` -> `next-best-practices`, `next-cache-components`, `next-upgrade`
-- `vue` -> `vue-best-practices`, `vue-router-best-practices`, `vue-testing-best-practices`
-- `testing` -> `playwright-cli`, `vitest`, `react-doctor`
+Prefer 1 skill.
 
-## Examples
+Use 2 only when the task needs two clear angles.
 
-- "deslop this card layout" -> `baseline-ui`
-- "make this page feel cleaner fast" -> `baseline-ui`
-- "tighten spacing and typography" -> `baseline-ui`
-- "clean up this component quickly" -> `baseline-ui`
-- "remove sloppy spacing and fix the hierarchy" -> `baseline-ui`
-- "fix this animation jank" -> `fixing-motion-performance`
-- "stabilize this transition on mobile" -> `fixing-motion-performance`
-- "fix AnimatePresence exit behavior" -> `mastering-animate-presence`
-- "audit this form accessibility" -> `fixing-accessibility`
-- "upgrade Next.js" -> `next-upgrade`
-- "build this in Vue" -> `vue-best-practices`
+Use 3 only for broad review, redesign, or multi-surface work.
 
-## Output shape
+Never use more than 3.
 
-- Best skill first.
-- 2 alternates only when they are genuinely useful.
-- Short reason for each choice.
-- Say `no skill needed` when the task is outside UI work.
+Route by topic, then stack, then specificity.
+
+Prefer specific skills over broad skills.
+
+Prefer framework-specific skills when the stack is obvious.
+
+For quick cleanup, prefer the most specific craft, visual, or layout skill available.
+
+If unsure, inspect categories and pick the safest narrow skill.

--- a/skills/ui-skills-root/SKILL.md
+++ b/skills/ui-skills-root/SKILL.md
@@ -11,7 +11,13 @@ metadata:
 
 You are the routing layer for UI Skills.
 
-Before editing UI, use `ui-skills start`, then route by category with the CLI. Select first. Implement after.
+This skill is shown by `npx ui-skills start` and is also available in the registry.
+
+Use it when an agent in Codex, Cursor, or Claude Code has a clear UI goal.
+
+If the goal is unclear, ask one short question.
+
+If the goal is clear, choose the right category, load the smallest useful skill context, then implement.
 
 ## Protocol
 

--- a/skills/ui-skills-root/SKILL.md
+++ b/skills/ui-skills-root/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: ui-skills-root
+description: Use when the user needs UI help and you must route by topic, stack, and intent to the smallest useful set of UI skills.
+---
+
+# UI Skills Root
+
+You are the router for UI Skills.
+
+Do not solve the request directly unless no skill fits.
+The registry contains both local `ibelick` skills and hosted skills from `ui-skills.com`; treat them as one routing pool.
+
+## Rules
+
+- Route by topic first, then repo stack, then specificity.
+- Prefer the smallest useful set of skills.
+- Default to 1 skill.
+- Never return more than 3 skills.
+- Prefer task-specific skills over broad polish skills.
+- Prefer framework-specific skills when the stack is obvious.
+- Return `no skill needed` if the request is not UI-related.
+- If confidence is low, ask one short clarifying question.
+
+## Routing order
+
+1. Detect the user's intent.
+2. Detect the repo stack.
+3. Map the request to one or more topics.
+4. Pick the best matching skill for those topics.
+5. Load only that skill, or up to 3 if the task is broad.
+
+## Topic examples
+
+- `accessibility` -> `fixing-accessibility`, `wcag-audit-patterns`, `audit-and-fix`
+- `motion` or `performance` -> `fixing-motion-performance`, `mastering-animate-presence`, `to-spring-or-not-to-spring`
+- `visual` or `craft` or quick cleanup -> `baseline-ui`, `frontend-design`, `emil-design-eng`, `make-interfaces-feel-better`
+- `baseline-ui` is the quick deslop / polish path for fast cleanup, spacing, hierarchy, and small UI fixes.
+- `systems` or `tooling` -> `shadcn`, `antfu`, `pnpm`, `vite`
+- `nextjs` -> `next-best-practices`, `next-cache-components`, `next-upgrade`
+- `vue` -> `vue-best-practices`, `vue-router-best-practices`, `vue-testing-best-practices`
+- `testing` -> `playwright-cli`, `vitest`, `react-doctor`
+
+## Examples
+
+- "deslop this card layout" -> `baseline-ui`
+- "make this page feel cleaner fast" -> `baseline-ui`
+- "tighten spacing and typography" -> `baseline-ui`
+- "clean up this component quickly" -> `baseline-ui`
+- "remove sloppy spacing and fix the hierarchy" -> `baseline-ui`
+- "fix this animation jank" -> `fixing-motion-performance`
+- "stabilize this transition on mobile" -> `fixing-motion-performance`
+- "fix AnimatePresence exit behavior" -> `mastering-animate-presence`
+- "audit this form accessibility" -> `fixing-accessibility`
+- "upgrade Next.js" -> `next-upgrade`
+- "build this in Vue" -> `vue-best-practices`
+
+## Output shape
+
+- Best skill first.
+- 2 alternates only when they are genuinely useful.
+- Short reason for each choice.
+- Say `no skill needed` when the task is outside UI work.

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -48,6 +48,71 @@ type RegistrySourceSkill = Omit<
 
 const registrySource: RegistrySourceSkill[] = [
   {
+    slug: "ui-skills-root",
+    user: "ibelick",
+    repo: "ui-skills",
+    rawUrl:
+      "https://raw.githubusercontent.com/ibelick/ui-skills/main/skills/ui-skills-root/SKILL.md",
+    githubUrl:
+      "https://github.com/ibelick/ui-skills/blob/main/skills/ui-skills-root/SKILL.md",
+    name: "ui-skills-root",
+    topics: ["systems", "tooling", "architecture"],
+    description:
+      "Use when the user needs UI help and you must route by topic, stack, and intent to the smallest useful set of UI skills.",
+  },
+  {
+    slug: "baseline-ui",
+    user: "ibelick",
+    repo: "ui-skills",
+    rawUrl:
+      "https://raw.githubusercontent.com/ibelick/ui-skills/main/skills/baseline-ui/SKILL.md",
+    githubUrl:
+      "https://github.com/ibelick/ui-skills/blob/main/skills/baseline-ui/SKILL.md",
+    name: "baseline-ui",
+    topics: ["systems", "visual", "craft"],
+    description:
+      "Quickly deslop UI code by fixing spacing, hierarchy, typography, and small layout issues. Use when the interface needs a fast cleanup or polish pass.",
+  },
+  {
+    slug: "fixing-accessibility",
+    user: "ibelick",
+    repo: "ui-skills",
+    rawUrl:
+      "https://raw.githubusercontent.com/ibelick/ui-skills/main/skills/fixing-accessibility/SKILL.md",
+    githubUrl:
+      "https://github.com/ibelick/ui-skills/blob/main/skills/fixing-accessibility/SKILL.md",
+    name: "fixing-accessibility",
+    topics: ["accessibility", "testing", "frontend"],
+    description:
+      "Audit and fix HTML accessibility issues including ARIA labels, keyboard navigation, focus management, color contrast, and form errors. Use when adding interactive controls, forms, dialogs, or reviewing WCAG compliance.",
+  },
+  {
+    slug: "fixing-metadata",
+    user: "ibelick",
+    repo: "ui-skills",
+    rawUrl:
+      "https://raw.githubusercontent.com/ibelick/ui-skills/main/skills/fixing-metadata/SKILL.md",
+    githubUrl:
+      "https://github.com/ibelick/ui-skills/blob/main/skills/fixing-metadata/SKILL.md",
+    name: "fixing-metadata",
+    topics: ["architecture", "frontend", "tooling"],
+    description:
+      "Audit and fix page metadata including titles, meta descriptions, Open Graph, Twitter cards, canonical URLs, and JSON-LD structured data. Use when shipping new pages or fixing SEO and social preview issues.",
+  },
+  {
+    slug: "fixing-motion-performance",
+    user: "ibelick",
+    repo: "ui-skills",
+    rawUrl:
+      "https://raw.githubusercontent.com/ibelick/ui-skills/main/skills/fixing-motion-performance/SKILL.md",
+    githubUrl:
+      "https://github.com/ibelick/ui-skills/blob/main/skills/fixing-motion-performance/SKILL.md",
+    name: "fixing-motion-performance",
+    topics: ["motion", "performance", "frontend"],
+    description:
+      "Audit and fix animation performance issues including layout thrashing, compositor properties, scroll-linked motion, and blur effects. Use when animations stutter, transitions jank, or reviewing CSS/JS animation performance.",
+  },
+  {
     slug: "frontend-design",
     user: "anthropics",
     repo: "skills",

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,4 +1,4 @@
-import { registry, type TopicSlug } from "./registry";
+import { registry, type TopicSlug } from "./registry.ts";
 
 export type Skill = {
   slug: string;

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,12 +1,4 @@
-import type { MarkdownInstance } from "astro";
-
 import { registry, type TopicSlug } from "./registry";
-
-type SkillFrontmatter = {
-  name?: string;
-  description?: string;
-  label?: string;
-};
 
 export type Skill = {
   slug: string;
@@ -16,22 +8,8 @@ export type Skill = {
   name: string;
   label: string;
   description?: string;
-  isRegistry?: boolean;
   topics?: TopicSlug[];
 };
-
-const localSkillTopics: Record<string, TopicSlug[]> = {
-  "ibelick/ui-skills-root": ["systems", "tooling", "architecture"],
-  "ibelick/baseline-ui": ["systems", "visual", "craft"],
-  "ibelick/fixing-accessibility": ["accessibility", "testing", "frontend"],
-  "ibelick/fixing-metadata": ["architecture", "frontend", "tooling"],
-  "ibelick/fixing-motion-performance": ["motion", "performance", "frontend"],
-};
-
-const skillModules = import.meta.glob<MarkdownInstance<SkillFrontmatter>>(
-  "/skills/*/SKILL.md",
-  { eager: true },
-);
 
 const titleize = (value: string) =>
   value
@@ -45,48 +23,22 @@ const titleize = (value: string) =>
     })
     .join(" ");
 
-const localSkills: Skill[] = Object.entries(skillModules).map(
-  ([path, module]) => {
-    const slug = path.split("/").at(-2) ?? "";
-    const name = module.frontmatter.name ?? slug;
-
-    return {
-      slug,
-      pathSlug: `ibelick/${slug}`,
-      sourceKey: "ibelick",
-      sourceLabel: "Ibelick",
-      name,
-      label: module.frontmatter.label ?? titleize(name),
-      description: module.frontmatter.description,
-      topics: localSkillTopics[`ibelick/${slug}`] ?? [],
-    };
-  },
-);
-
-const registrySkills: Skill[] = registry
-  .filter((s) => !localSkills.some((ls) => ls.pathSlug === s.pathSlug))
-  .map((s) => ({
-    slug: s.slug,
-    pathSlug: s.pathSlug,
-    sourceKey: s.sourceKey,
-    sourceLabel: s.sourceLabel,
-    name: s.name ?? s.slug,
-    label: titleize(s.name ?? s.slug),
-    description: s.description,
-    topics: s.topics ?? [],
-    isRegistry: true,
-  }));
-
-export const skills: Skill[] = [...localSkills, ...registrySkills].sort(
+export const skills: Skill[] = registry.map((skill) => ({
+  slug: skill.slug,
+  pathSlug: skill.pathSlug,
+  sourceKey: skill.sourceKey,
+  sourceLabel: skill.sourceLabel,
+  name: skill.name ?? skill.slug,
+  label: titleize(skill.name ?? skill.slug),
+  description: skill.description,
+  topics: skill.topics ?? [],
+})).sort(
   (a, b) => {
     if (a.slug === "ui-skills-root") return -1;
     if (b.slug === "ui-skills-root") return 1;
 
     if (a.slug === "baseline-ui") return -1;
     if (b.slug === "baseline-ui") return 1;
-
-    if (!a.isRegistry && b.isRegistry) return -1;
-    if (a.isRegistry && !b.isRegistry) return 1;
 
     return a.pathSlug.localeCompare(b.pathSlug);
   },

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -21,6 +21,7 @@ export type Skill = {
 };
 
 const localSkillTopics: Record<string, TopicSlug[]> = {
+  "ibelick/ui-skills-root": ["systems", "tooling", "architecture"],
   "ibelick/baseline-ui": ["systems", "visual", "craft"],
   "ibelick/fixing-accessibility": ["accessibility", "testing", "frontend"],
   "ibelick/fixing-metadata": ["architecture", "frontend", "tooling"],
@@ -78,6 +79,9 @@ const registrySkills: Skill[] = registry
 
 export const skills: Skill[] = [...localSkills, ...registrySkills].sort(
   (a, b) => {
+    if (a.slug === "ui-skills-root") return -1;
+    if (b.slug === "ui-skills-root") return 1;
+
     if (a.slug === "baseline-ui") return -1;
     if (b.slug === "baseline-ui") return 1;
 

--- a/src/data/topics.ts
+++ b/src/data/topics.ts
@@ -1,4 +1,4 @@
-import type { TopicSlug } from "./registry";
+import type { TopicSlug } from "./registry.ts";
 
 export type Topic = {
   slug: TopicSlug;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import firaMono400Woff2 from "@fontsource/fira-mono/files/fira-mono-latin-400-no
 import Button from "../ui/button.astro";
 import NewsletterInput from "../ui/newsletter-input";
 import { skills } from "../data/skills";
+import { registry } from "../data/registry";
 import { CommandDialog } from "../ui/command-dialog";
 
 type Props = {
@@ -61,40 +62,42 @@ const twitterImageAltText = twitterImageAlt ?? "UI Skills social preview image";
 const ogTypeValue = ogType ?? "website";
 const siteNameValue = siteName ?? "UI Skills";
 const twitterSiteHandle = twitterSite ?? "@ibelick";
-const skillRawModules = import.meta.glob<string>("/skills/*/SKILL.md", {
-  eager: true,
-  query: "?raw",
-  import: "default",
-});
-const skillRawBySlug = new Map(
-  Object.entries(skillRawModules).map(([path, raw]) => [
-    path.split("/").at(-2) ?? "",
-    raw,
-  ]),
-);
-const buildSearchContent = (skill: (typeof skills)[number]) => {
-  const raw = skillRawBySlug.get(skill.slug) ?? "";
-  const text = (skill.description ?? "") + " " + raw;
-
-  return text
+const normalizeSearchContent = (value: string) =>
+  value
     .replace(/^---[\s\S]*?---/, " ")
     .replace(/`{1,3}[\s\S]*?`{1,3}/g, " ")
     .replace(/<\/script/gi, "<\\/script")
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, 2000);
-};
 
-const commandItems = skills.map((skill) => ({
-  slug: skill.slug,
-  pathSlug: skill.pathSlug,
-  label: skill.label,
-  sourceLabel: skill.sourceLabel,
-  description: skill.description,
-  searchContent: skill.isRegistry
-    ? (skill.description ?? "")
-    : buildSearchContent(skill),
-}));
+const commandItems = await Promise.all(
+  skills.map(async (skill) => {
+    const registryEntry = registry.find((entry) => entry.pathSlug === skill.pathSlug);
+    let searchContent = skill.description ?? "";
+
+    if (registryEntry?.rawUrl) {
+      try {
+        const response = await fetch(registryEntry.rawUrl);
+        if (response.ok) {
+          const raw = await response.text();
+          searchContent = normalizeSearchContent(`${skill.description ?? ""} ${raw}`);
+        }
+      } catch {
+        searchContent = normalizeSearchContent(searchContent);
+      }
+    }
+
+    return {
+      slug: skill.slug,
+      pathSlug: skill.pathSlug,
+      label: skill.label,
+      sourceLabel: skill.sourceLabel,
+      description: skill.description,
+      searchContent,
+    };
+  }),
+);
 ---
 
 <!doctype html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import SkillCard from "../ui/skill-card.astro";
 const MAX_SKILLS = 18;
 
 const FEATURED_PATH_SLUGS = [
+  "ibelick/ui-skills-root",
   "ibelick/baseline-ui",
   "ibelick/fixing-accessibility",
   "ibelick/fixing-motion-performance",

--- a/src/pages/skills/[...slug].astro
+++ b/src/pages/skills/[...slug].astro
@@ -1,7 +1,6 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import CodeBlock from "../../ui/code-block.astro";
-import type { MarkdownInstance } from "astro";
 import { skills, type Skill } from "../../data/skills";
 import { topicBySlug, relatedTopicSlugs } from "../../data/topics";
 import type { TopicSlug } from "../../data/registry";
@@ -12,12 +11,6 @@ import SkillCard from "../../ui/skill-card.astro";
 import SkillNav from "../../ui/skill-nav.astro";
 import TopicTag from "../../ui/topic-tag.astro";
 import { marked } from "marked";
-
-type SkillFrontmatter = {
-  name?: string;
-  description?: string;
-  label?: string;
-};
 
 const titleize = (value: string) =>
   value
@@ -44,25 +37,6 @@ const rewriteRelativeLinksToRepo = (html: string, baseUrl: string) =>
     }
   });
 
-const skillModules = import.meta.glob<MarkdownInstance<SkillFrontmatter>>(
-  "/skills/*/SKILL.md",
-  { eager: true },
-);
-const skillRawModules = import.meta.glob<string>("/skills/*/SKILL.md", {
-  eager: true,
-  query: "?raw",
-  import: "default",
-});
-const skillEntries = Object.entries(skillModules).map(([path, module]) => {
-  const entrySlug = path.split("/").at(-2) ?? "";
-
-  return { slug: entrySlug, module };
-});
-const skillRawEntries = Object.entries(skillRawModules).map(([path, raw]) => {
-  const entrySlug = path.split("/").at(-2) ?? "";
-
-  return { slug: entrySlug, raw };
-});
 
 export function getStaticPaths() {
   const topicGroupPaths = Array.from(
@@ -389,13 +363,13 @@ const pageDescription = skill
 
 let skillRaw = "";
 let displayContent = "";
-let SkillContent: any = null;
 let githubUrl = "";
 
-if (skill?.isRegistry) {
+if (skill) {
   const registryEntry = registry.find(
     (entry: RegistrySkill) => entry.pathSlug === skill.pathSlug,
   );
+
   if (registryEntry) {
     try {
       const response = await fetch(registryEntry.rawUrl);
@@ -422,52 +396,26 @@ if (skill?.isRegistry) {
       displayContent = `<p>Error: ${e instanceof Error ? e.message : String(e)}</p>`;
     }
   }
-} else if (skill) {
-  const localSlug = skill.slug;
-  const skillModule = skillEntries.find(
-    (entry) => entry.slug === localSlug,
-  )?.module;
-  skillRaw =
-    skillRawEntries.find((entry) => entry.slug === localSlug)?.raw ?? "";
-  SkillContent = skillModule?.Content;
 }
 
-const commandSegments = [
-  ...(skill?.isRegistry
-    ? (() => {
-        const registryEntry = registry.find(
-          (entry: RegistrySkill) => entry.pathSlug === skill.pathSlug,
-        );
-        const repoUrl = registryEntry
-          ? `https://github.com/${registryEntry.user}/${registryEntry.repo}`
-          : "https://github.com/ibelick/ui-skills";
-        const skillName =
-          registryEntry?.name ?? skill?.slug ?? canonicalSkillPath;
+const commandSegments = (() => {
+  const registryEntry = skill
+    ? registry.find((entry: RegistrySkill) => entry.pathSlug === skill.pathSlug)
+    : undefined;
+  const repoUrl = registryEntry
+    ? `https://github.com/${registryEntry.user}/${registryEntry.repo}`
+    : "https://github.com/ibelick/ui-skills";
+  const skillName = registryEntry?.name ?? skill?.slug ?? canonicalSkillPath;
 
-        return [
-          { text: "npx", className: "text-[#953800]" },
-          { text: " skills", className: "text-[#0a3069]" },
-          { text: " add", className: "text-[#0550ae]" },
-          { text: ` ${repoUrl}`, className: "text-parchment-400" },
-          { text: " --skill", className: "text-[#0550ae]" },
-          { text: ` ${skillName}`, className: "text-parchment-400" },
-        ];
-      })()
-    : [
-        { text: "npx", className: "text-[#953800]" },
-        { text: " skills", className: "text-[#0a3069]" },
-        { text: " add", className: "text-[#0550ae]" },
-        {
-          text: " https://github.com/ibelick/ui-skills",
-          className: "text-parchment-400",
-        },
-        { text: " --skill", className: "text-[#0550ae]" },
-        {
-          text: ` ${skill?.slug ?? canonicalSkillPath}`,
-          className: "text-parchment-400",
-        },
-      ]),
-];
+  return [
+    { text: "npx", className: "text-[#953800]" },
+    { text: " skills", className: "text-[#0a3069]" },
+    { text: " add", className: "text-[#0550ae]" },
+    { text: ` ${repoUrl}`, className: "text-parchment-400" },
+    { text: " --skill", className: "text-[#0550ae]" },
+    { text: ` ${skillName}`, className: "text-parchment-400" },
+  ];
+})();
 ---
 
 <Layout
@@ -633,11 +581,7 @@ const commandSegments = [
                 description={skill.description}
                 dataEvent="install"
               >
-                {SkillContent ? (
-                  <SkillContent />
-                ) : (
-                  <div set:html={displayContent} />
-                )}
+                <div set:html={displayContent} />
               </SkillContentCard>
 
               {relatedSkills.length > 0 ? (

--- a/src/pages/skills/[...slug]/llms.txt.ts
+++ b/src/pages/skills/[...slug]/llms.txt.ts
@@ -2,18 +2,6 @@ import type { APIRoute } from "astro";
 import { skills } from "../../../data/skills";
 import { registry } from "../../../data/registry";
 
-const skillRawModules = import.meta.glob<string>("/skills/*/SKILL.md", {
-  eager: true,
-  query: "?raw",
-  import: "default",
-});
-
-const skillRawEntries = Object.entries(skillRawModules).map(([path, raw]) => {
-  const entrySlug = path.split("/").at(-2) ?? "";
-
-  return { slug: entrySlug, raw };
-});
-
 export function getStaticPaths() {
   return skills.map((skill) => ({
     params: { slug: skill.pathSlug },
@@ -27,22 +15,6 @@ export const GET: APIRoute = async ({ params }) => {
 
   if (!skillEntry) {
     return new Response("Skill not found", { status: 404 });
-  }
-
-  if (!skillEntry.isRegistry) {
-    const localSkill = skillRawEntries.find(
-      (entry) => entry.slug === skillEntry.slug,
-    );
-    if (!localSkill) {
-      return new Response("Skill not found", { status: 404 });
-    }
-
-    return new Response(localSkill.raw, {
-      headers: {
-        "Content-Type": "text/plain; charset=utf-8",
-        "X-Robots-Tag": "noindex, nofollow",
-      },
-    });
   }
 
   const registrySkill = registry.find((entry) => entry.pathSlug === pathSlug);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
   ],
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
## Summary

Adds a new `ui-skills` CLI and updates `ui-skills-root` to be the routing skill for UI work.

## Changes

- Replaced the old installer-style CLI with `start`, `categories`, `list`, and `get`
- `start` prints the local root skill protocol
- Made CLI input strict
- Updated the root skill to guide topic-first routing
- Consolidated CLI usage into the README

## Verification

- `./bin/ui-skills start`
- `./bin/ui-skills categories`
- `./bin/ui-skills list --category motion`
- `./bin/ui-skills get baseline-ui`
- `npm run typecheck`
- `npm run build`