### PR TITLE
Add slide-wright skill to registry

### DIFF
--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -1108,6 +1108,19 @@ const registrySource: RegistrySourceSkill[] = [
       "Create animation-rich HTML presentations from scratch or convert PPT/PPTX files into polished web slides.",
   },
   {
+    slug: "slide-wright",
+    user: "arifszn",
+    repo: "slide-wright",
+    rawUrl:
+      "https://raw.githubusercontent.com/arifszn/slide-wright/main/SKILL.md",
+    githubUrl:
+      "https://github.com/arifszn/slide-wright/blob/main/SKILL.md",
+    name: "slide-wright",
+    topics: ["video", "visual", "craft"],
+    description:
+      "Create beautiful, animated web presentations from a topic, rough notes, or an outline. Generates a custom theme and a short two-slide preview, then builds the full deck only once the user confirms the direction. Use when the user wants to make slides, a presentation, a talk deck, or a pitch deck.",
+  },
+  {
     slug: "shadcn",
     user: "shadcn-ui",
     repo: "ui",


### PR DESCRIPTION
Adds [`slide-wright`](https://github.com/arifszn/slide-wright) to the skill registry.

## What it does

Turns a topic or rough notes into a polished, animated web presentation as a single self-contained HTML file. It proposes a custom theme and a two-slide preview, then builds the full deck only once the user confirms the direction.

## Registry entry

Added to `src/data/registry.ts`:

```ts
{
  slug: "slide-wright",
  user: "arifszn",
  repo: "slide-wright",
  rawUrl:      "https://raw.githubusercontent.com/arifszn/slide-wright/main/SKILL.md",
  githubUrl:   "https://github.com/arifszn/slide-wright/blob/main/SKILL.md",
  name: "slide-wright",
  topics: ["video", "visual", "craft"],
  description:
    "Create beautiful, animated web presentations from a topic, rough notes, or an outline. Generates a custom theme and a short two-slide preview, then builds the full deck only once the user confirms the direction. Use when the user wants to make slides, a presentation, a talk deck, or a pitch deck.",
}
```

- `SKILL.md` lives at the repo root, so the page's relative-link rewriter resolves the skill's `reference/*.md` files correctly.
- `description` is taken verbatim from the skill's frontmatter.
- Follows the same pattern as other presentation skills already in the registry (`frontend-slides`, `slidev`).

## Validation

`npm run typecheck` passes (0 errors).