### PR TITLE
Add UIZZE — STOP UI SLOP to the registry

### DIFF
--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -128,13 +128,12 @@ const registrySource: RegistrySourceSkill[] = [
       "Create distinctive, production-grade frontend interfaces with high design quality. Generates creative, polished code and UI design that avoids generic AI aesthetics.",
   },
   {
-    slug: "uizze-ui-research",
+    slug: "anti-ai-ui-slop",
     user: "aislon",
     repo: "uizze-mcp",
     rawUrl:
-      "https://raw.githubusercontent.com/aislon/uizze-mcp/main/skills/uizze-ui-research/SKILL.md",
-    githubUrl:
-      "https://github.com/aislon/uizze-mcp/blob/main/skills/uizze-ui-research/SKILL.md",
+      "https://uizze.com/.well-known/agent-skills/anti-ai-ui-slop/SKILL.md",
+    githubUrl: "https://uizze.com",
     name: "UIZZE: Stop AI UI Slop",
     topics: ["taste", "visual", "systems"],
     description:

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -135,10 +135,10 @@ const registrySource: RegistrySourceSkill[] = [
       "https://raw.githubusercontent.com/aislon/uizze-mcp/main/skills/uizze-ui-research/SKILL.md",
     githubUrl:
       "https://github.com/aislon/uizze-mcp/blob/main/skills/uizze-ui-research/SKILL.md",
-    name: "uizze-ui-research",
+    name: "UIZZE: Stop AI UI Slop",
     topics: ["taste", "visual", "systems"],
     description:
-      "Use when building, reviewing, or improving a web or iOS product UI and you need real UI references, explicit design constraints, or implementation validation through UIZZE. The public UIZZE catalog is free to browse. Hosted UIZZE MCP workflows require full access and a UIZZE agent token.",
+      "Stop Codex, Claude Code, and Cursor from shipping generic AI UI slop. Ground web or iOS UI work in real interface evidence, lock product-specific constraints, then validate, audit, and critique the result through UIZZE. Paid UIZZE access and an agent token are required.",
   },
   {
     slug: "remotion-best-practices",

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -128,6 +128,19 @@ const registrySource: RegistrySourceSkill[] = [
       "Create distinctive, production-grade frontend interfaces with high design quality. Generates creative, polished code and UI design that avoids generic AI aesthetics.",
   },
   {
+    slug: "uizze-ui-research",
+    user: "aislon",
+    repo: "uizze-mcp",
+    rawUrl:
+      "https://raw.githubusercontent.com/aislon/uizze-mcp/main/skills/uizze-ui-research/SKILL.md",
+    githubUrl:
+      "https://github.com/aislon/uizze-mcp/blob/main/skills/uizze-ui-research/SKILL.md",
+    name: "uizze-ui-research",
+    topics: ["taste", "visual", "systems"],
+    description:
+      "Use when building, reviewing, or improving a web or iOS product UI and you need real UI references, explicit design constraints, or implementation validation through UIZZE. The public UIZZE catalog is free to browse. Hosted UIZZE MCP workflows require full access and a UIZZE agent token.",
+  },
+  {
     slug: "remotion-best-practices",
     user: "remotion-dev",
     repo: "skills",

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -138,7 +138,7 @@ const registrySource: RegistrySourceSkill[] = [
     name: "UIZZE: Stop AI UI Slop",
     topics: ["taste", "visual", "systems"],
     description:
-      "Stop Codex, Claude Code, and Cursor from shipping generic AI UI slop. Ground web or iOS UI work in real interface evidence, lock product-specific constraints, then validate, audit, and critique the result through UIZZE. Paid UIZZE access and an agent token are required.",
+      "Stop Codex, Claude Code, and Cursor from shipping generic AI UI slop with uizze.com. Ground web or iOS UI work in real interface evidence, lock product-specific constraints, then validate, audit, and critique the result. Paid UIZZE access and an agent token are required.",
   },
   {
     slug: "remotion-best-practices",

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -128,16 +128,16 @@ const registrySource: RegistrySourceSkill[] = [
       "Create distinctive, production-grade frontend interfaces with high design quality. Generates creative, polished code and UI design that avoids generic AI aesthetics.",
   },
   {
-    slug: "anti-ai-ui-slop",
-    user: "aislon",
-    repo: "uizze-mcp",
+    slug: "anti-ui-slop",
+    user: "samuelbushi",
+    repo: "uizze",
     rawUrl:
-      "https://uizze.com/.well-known/agent-skills/anti-ai-ui-slop/SKILL.md",
+      "https://uizze.com/.well-known/agent-skills/anti-ui-slop/SKILL.md",
     githubUrl: "https://uizze.com",
-    name: "UIZZE: Stop AI UI Slop",
+    name: "UIZZE — STOP UI SLOP",
     topics: ["taste", "visual", "systems"],
     description:
-      "Stop Codex, Claude Code, and Cursor from shipping generic AI UI slop with uizze.com. Ground web or iOS UI work in real interface evidence, lock product-specific constraints, then validate, audit, and critique the result. Paid UIZZE access and an agent token are required.",
+      "If your UI looks AI-generated, you've already lost the first impression. Ground Codex, Claude Code, Cursor, and Copilot in 800,000+ real web and iOS screens, then force a hard finish gate before generic UI ships.",
   },
   {
     slug: "remotion-best-practices",


### PR DESCRIPTION
## What changed

- adds the canonical domain-hosted `anti-ui-slop` skill
- uses `https://uizze.com/.well-known/agent-skills/anti-ui-slop/SKILL.md`
- classifies it under `taste`, `visual`, and `systems`

## Why it fits

**STOP UI SLOP.** The free skill grounds Codex, Claude Code, Cursor, and Copilot in 800,000+ real web and iOS screens, locks a product-specific design contract, and forces a hard finish gate before generic UI ships.

Install:
`npx skills add https://uizze.com --skill anti-ui-slop`

## Validation

- canonical index and SKILL.md return HTTP 200
- source skill passes the Agent Skills validator
- branch diff is clean

**Affiliation:** first-party UIZZE submission.