### PR TITLE
Add Frontend Expert suite to the registry

### DIFF
--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -2392,43 +2392,17 @@ const registrySource: RegistrySourceSkill[] = [
       "Local-first architecture guidance for instant-feeling web apps, optimistic updates, bundle loading, offline behavior, and responsive UI motion.",
   },
   {
-    slug: "anti-ai-slop",
+    slug: "frontend-expert",
     user: "sukirman1901",
     repo: "frontend-expert",
     rawUrl:
-      "https://raw.githubusercontent.com/sukirman1901/frontend-expert/main/skills/anti-ai-slop/SKILL.md",
+      "https://raw.githubusercontent.com/sukirman1901/frontend-expert/main/skills/frontend-expert/SKILL.md",
     githubUrl:
-      "https://github.com/sukirman1901/frontend-expert/blob/main/skills/anti-ai-slop/SKILL.md",
-    name: "anti-ai-slop",
-    topics: ["taste", "visual", "craft"],
+      "https://github.com/sukirman1901/frontend-expert/blob/main/skills/frontend-expert/SKILL.md",
+    name: "frontend-expert",
+    topics: ["systems", "craft", "frontend"],
     description:
-      "Detect and fix AI aesthetic anti-patterns — purple/indigo defaults, generic heroes, Lorem, shadow-heavy cards — so product UI ships with intentional craft instead of template slop.",
-  },
-  {
-    slug: "ui-feel",
-    user: "sukirman1901",
-    repo: "frontend-expert",
-    rawUrl:
-      "https://raw.githubusercontent.com/sukirman1901/frontend-expert/main/skills/ui-feel/SKILL.md",
-    githubUrl:
-      "https://github.com/sukirman1901/frontend-expert/blob/main/skills/ui-feel/SKILL.md",
-    name: "ui-feel",
-    topics: ["craft", "interaction", "visual"],
-    description:
-      "Polish the micro-details that make interfaces feel better — concentric radius, optical alignment, press scale, hit areas, interruptible motion, and no transition:all.",
-  },
-  {
-    slug: "app-shell-routing",
-    user: "sukirman1901",
-    repo: "frontend-expert",
-    rawUrl:
-      "https://raw.githubusercontent.com/sukirman1901/frontend-expert/main/skills/app-shell-routing/SKILL.md",
-    githubUrl:
-      "https://github.com/sukirman1901/frontend-expert/blob/main/skills/app-shell-routing/SKILL.md",
-    name: "app-shell-routing",
-    topics: ["systems", "frontend", "architecture"],
-    description:
-      "Modern product app shell — logo, topbar theme icon, avatar account menu, custom filter selects, drawer nav, and shareable routes — not bare settings pages or native OS chrome.",
+      "Frontend Expert suite for shipping product web UI — judgment, tokens, responsive, motion, anti-AI-slop, modern shell chrome, forms/data, a11y, testing, and polish loop. One pack; chat-first routing into the full skill set.",
   },
 ];
 

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -2391,6 +2391,45 @@ const registrySource: RegistrySourceSkill[] = [
     description:
       "Local-first architecture guidance for instant-feeling web apps, optimistic updates, bundle loading, offline behavior, and responsive UI motion.",
   },
+  {
+    slug: "anti-ai-slop",
+    user: "sukirman1901",
+    repo: "frontend-expert",
+    rawUrl:
+      "https://raw.githubusercontent.com/sukirman1901/frontend-expert/main/skills/anti-ai-slop/SKILL.md",
+    githubUrl:
+      "https://github.com/sukirman1901/frontend-expert/blob/main/skills/anti-ai-slop/SKILL.md",
+    name: "anti-ai-slop",
+    topics: ["taste", "visual", "craft"],
+    description:
+      "Detect and fix AI aesthetic anti-patterns — purple/indigo defaults, generic heroes, Lorem, shadow-heavy cards — so product UI ships with intentional craft instead of template slop.",
+  },
+  {
+    slug: "ui-feel",
+    user: "sukirman1901",
+    repo: "frontend-expert",
+    rawUrl:
+      "https://raw.githubusercontent.com/sukirman1901/frontend-expert/main/skills/ui-feel/SKILL.md",
+    githubUrl:
+      "https://github.com/sukirman1901/frontend-expert/blob/main/skills/ui-feel/SKILL.md",
+    name: "ui-feel",
+    topics: ["craft", "interaction", "visual"],
+    description:
+      "Polish the micro-details that make interfaces feel better — concentric radius, optical alignment, press scale, hit areas, interruptible motion, and no transition:all.",
+  },
+  {
+    slug: "app-shell-routing",
+    user: "sukirman1901",
+    repo: "frontend-expert",
+    rawUrl:
+      "https://raw.githubusercontent.com/sukirman1901/frontend-expert/main/skills/app-shell-routing/SKILL.md",
+    githubUrl:
+      "https://github.com/sukirman1901/frontend-expert/blob/main/skills/app-shell-routing/SKILL.md",
+    name: "app-shell-routing",
+    topics: ["systems", "frontend", "architecture"],
+    description:
+      "Modern product app shell — logo, topbar theme icon, avatar account menu, custom filter selects, drawer nav, and shareable routes — not bare settings pages or native OS chrome.",
+  },
 ];
 
 const buildInitialPathSlug = (entry: RegistrySourceSkill) => {


### PR DESCRIPTION
## What changed

Adds **one** registry entry for the **Frontend Expert** suite:

- Slug: `frontend-expert`
- Repo: [sukirman1901/frontend-expert](https://github.com/sukirman1901/frontend-expert) (MIT)
- Source: `skills/frontend-expert/SKILL.md` (suite root — routes into the full pack)
- Topics: `systems`, `craft`, `frontend`

## Why one entry

Frontend Expert is a **single suite** (not three unrelated tips). The catalog skill is the pack entry point; domain skills live in the same repo.

Current pack surface (**22 skills · E1–E23**), including:

- judgment → tokens → shell/data/forms → components → **responsive** → **motion** (hand-roll vocabulary) → anti-slop → feel → a11y → polish loop
- **marketing-landing** — section stack (hero → logo cloud → features → … → CTA → footer); hand-roll, not a block-registry install default
- Shell chrome defaults (theme in topbar, avatar → account menu, custom selects)

Agents that install this entry should follow the suite root + `AGENTS.md` intent map — they do **not** need separate registry rows per domain skill.

## Validation

- Raw SKILL.md URL HTTP 200
- `npm run typecheck` — passed
- `npm run build` — passed