### PR TITLE
feat: add forms-ui skill to registry

### DIFF
--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -2755,6 +2755,19 @@ const registrySource: RegistrySourceSkill[] = [
     description:
       "Build an immersive scroll-scrubbed 3D world landing page for any brand with Higgsfield-generated scenes, seamless camera clips, and a portable scroll-scrub engine.",
   },
+  {
+    slug: "forms-ui",
+    user: "Hotragn",
+    repo: "UI-UX-Skills-Contribution",
+    rawUrl:
+      "https://raw.githubusercontent.com/Hotragn/UI-UX-Skills-Contribution/main/skills/forms-ui/SKILL.md",
+    githubUrl:
+      "https://github.com/Hotragn/UI-UX-Skills-Contribution/blob/main/skills/forms-ui/SKILL.md",
+    name: "forms-ui",
+    topics: ["interaction", "accessibility", "craft"],
+    description:
+      "Build forms that are fast to complete, hard to get wrong, and accessible by default. Use when creating or reviewing any form, input, validation, or submission flow.",
+  },
 ];
 
 const buildInitialPathSlug = (entry: RegistrySourceSkill) => {


### PR DESCRIPTION
Adds a **forms-ui** skill to the registry.

Forms are one of the most common UI surfaces and one AI most reliably gets wrong (placeholder-as-label, validate-on-every-keystroke, disabled submit buttons, no submitting state). There's no dedicated forms skill in the registry today, so this fills a real gap.

The skill follows the `baseline-ui` MUST/SHOULD format and covers: native `<form>` structure, labels over placeholders, correct input `type`/`autocomplete`, validate-on-submit-then-blur, accessible inline errors (`aria-describedby`/`aria-invalid`), the four submission states (idle/submitting/success/error), focus management, 44px targets, and an anti-patterns checklist.

- Hosted at: https://github.com/Hotragn/UI-UX-Skills-Contribution/blob/main/skills/forms-ui/SKILL.md
- rawUrl verified returning 200.
- Single registry entry in `src/data/registry.ts`; topics: interaction, accessibility, craft.

Happy to adjust topics, wording, or scope to fit how you'd like it categorized.
