### PR TITLE
Add WebMCP tools for agent page actions

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,6 +6,7 @@ import { skills } from "../data/skills";
 import Footer from "../ui/footer.astro";
 import { CommandDialog } from "../ui/command-dialog";
 import GitHubStarButton from "../ui/github-star-button.astro";
+import { WebMcpTools } from "../ui/webmcp-tools";
 import { serializeJsonLd } from "../lib/serialize-json-ld";
 
 type Props = {
@@ -104,6 +105,7 @@ const githubStars = await getGithubStars();
     }
   </head>
   <body>
+    <WebMcpTools client:load />
     <a
       href="#main-content"
       class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-white focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-black"

--- a/src/lib/webmcp-tools.ts
+++ b/src/lib/webmcp-tools.ts
@@ -1,0 +1,177 @@
+type WebMcpTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (args: Record<string, unknown>) => Promise<unknown>;
+  annotations?: Record<string, unknown>;
+};
+
+type ModelContext = {
+  registerTool: (tool: WebMcpTool) => void;
+  unregisterTool?: (name: string) => void;
+};
+
+declare global {
+  interface Navigator {
+    modelContext?: ModelContext;
+  }
+}
+
+type SkillSummary = {
+  slug: string;
+  pathSlug: string;
+  label: string;
+  description?: string;
+};
+
+function getModelContext(): ModelContext | null {
+  if (typeof navigator === "undefined") return null;
+  if (!("modelContext" in navigator) || !navigator.modelContext) return null;
+  return navigator.modelContext;
+}
+
+async function fetchRegistry(): Promise<{
+  registry: Array<{
+    slug: string;
+    pathSlug: string;
+    name: string;
+    description?: string;
+  }>;
+}> {
+  const response = await fetch("/skills/registry.json");
+  if (!response.ok) {
+    throw new Error(`Registry request failed (${response.status})`);
+  }
+  return (await response.json()) as {
+    registry: Array<{
+      slug: string;
+      pathSlug: string;
+      name: string;
+      description?: string;
+    }>;
+  };
+}
+
+function toSummaries(
+  registry: Array<{
+    slug: string;
+    pathSlug: string;
+    name: string;
+    description?: string;
+  }>,
+): SkillSummary[] {
+  return registry.map((skill) => ({
+    slug: skill.slug,
+    pathSlug: skill.pathSlug,
+    label: skill.name,
+    description: skill.description,
+  }));
+}
+
+export function registerWebMcpTools(signal?: AbortSignal): void {
+  const modelContext = getModelContext();
+  if (!modelContext) return;
+
+  const tools: WebMcpTool[] = [
+    {
+      name: "list_ui_skills",
+      description:
+        "List UI Skills from the public catalog with slug, path, and description.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Optional case-insensitive filter over name/description.",
+          },
+        },
+        additionalProperties: false,
+      },
+      annotations: { readOnlyHint: true },
+      execute: async (args) => {
+        const query =
+          typeof args.query === "string" ? args.query.trim().toLowerCase() : "";
+        const { registry } = await fetchRegistry();
+        let skills = toSummaries(registry);
+        if (query) {
+          skills = skills.filter((skill) => {
+            const haystack = `${skill.label} ${skill.slug} ${skill.description ?? ""}`.toLowerCase();
+            return haystack.includes(query);
+          });
+        }
+        return {
+          count: skills.length,
+          skills: skills.slice(0, 50),
+        };
+      },
+    },
+    {
+      name: "open_ui_skill",
+      description:
+        "Navigate the browser to a UI skill page by slug or pathSlug.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          slug: {
+            type: "string",
+            description: "Skill slug such as baseline-ui or improve-ui.",
+          },
+          pathSlug: {
+            type: "string",
+            description: "Optional owner/slug path such as ibelick/baseline-ui.",
+          },
+        },
+        additionalProperties: false,
+      },
+      execute: async (args) => {
+        const { registry } = await fetchRegistry();
+        const slug = typeof args.slug === "string" ? args.slug : "";
+        const pathSlug = typeof args.pathSlug === "string" ? args.pathSlug : "";
+        const match = registry.find(
+          (skill) =>
+            skill.slug === slug ||
+            skill.pathSlug === pathSlug ||
+            skill.pathSlug === slug ||
+            skill.pathSlug.endsWith(`/${slug}`),
+        );
+        if (!match) {
+          return { error: `Skill not found for slug="${slug}" pathSlug="${pathSlug}"` };
+        }
+        const href = `/skills/${match.pathSlug}`;
+        window.location.assign(href);
+        return { ok: true, href, skill: match.name };
+      },
+    },
+    {
+      name: "get_ui_skills_overview",
+      description:
+        "Fetch the site llms.txt overview for agents (navigation + skill catalog summary).",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      annotations: { readOnlyHint: true },
+      execute: async () => {
+        const response = await fetch("/llms.txt");
+        if (!response.ok) {
+          return { error: `llms.txt request failed (${response.status})` };
+        }
+        const text = await response.text();
+        return { contentType: "text/plain", text };
+      },
+    },
+  ];
+
+  for (const tool of tools) {
+    modelContext.registerTool(tool);
+  }
+
+  const cleanup = () => {
+    for (const tool of tools) {
+      modelContext.unregisterTool?.(tool.name);
+    }
+  };
+
+  signal?.addEventListener("abort", cleanup, { once: true });
+}

--- a/src/ui/webmcp-tools.tsx
+++ b/src/ui/webmcp-tools.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+import { registerWebMcpTools } from "../lib/webmcp-tools";
+
+/** Registers WebMCP tools on browsers that expose navigator.modelContext. */
+export function WebMcpTools() {
+  useEffect(() => {
+    const controller = new AbortController();
+    registerWebMcpTools(controller.signal);
+    return () => controller.abort();
+  }, []);
+
+  return null;
+}

--- a/tests/webmcp-tools.test.ts
+++ b/tests/webmcp-tools.test.ts
@@ -1,0 +1,51 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerWebMcpTools } from "../src/lib/webmcp-tools.ts";
+
+describe("webmcp tools", () => {
+  test("registers tools when navigator.modelContext is available", () => {
+    const registered: string[] = [];
+    const originalNavigator = globalThis.navigator;
+
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        modelContext: {
+          registerTool: (tool: { name: string }) => {
+            registered.push(tool.name);
+          },
+        },
+      },
+    });
+
+    try {
+      registerWebMcpTools();
+      assert.ok(registered.includes("list_ui_skills"));
+      assert.ok(registered.includes("open_ui_skill"));
+      assert.ok(registered.includes("get_ui_skills_overview"));
+    } finally {
+      Object.defineProperty(globalThis, "navigator", {
+        configurable: true,
+        value: originalNavigator,
+      });
+    }
+  });
+
+  test("no-ops when WebMCP is unavailable", () => {
+    const originalNavigator = globalThis.navigator;
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {},
+    });
+
+    try {
+      assert.doesNotThrow(() => registerWebMcpTools());
+    } finally {
+      Object.defineProperty(globalThis, "navigator", {
+        configurable: true,
+        value: originalNavigator,
+      });
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Exposes site actions to browser agents via the WebMCP API.

### Tools

On page load (when `navigator.modelContext` exists):

- `list_ui_skills` — list/filter the public skills catalog
- `open_ui_skill` — navigate to a skill page
- `get_ui_skills_overview` — fetch `/llms.txt`

Uses `registerTool` with JSON Schema `inputSchema` and an `AbortController` cleanup on unmount.

## Validation

- Unit tests for registration / no-op when WebMCP is unavailable

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe5cc-f36e-7b68-8a77-6241958f7999?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe5cc-f36e-7b68-8a77-6241958f7999&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

