### PR TITLE
Add skill health check and fix broken registry sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prebuild": "node --import tsx ./scripts/precompute-agent-skills-digests.mjs",
     "build": "astro build",
     "postbuild": "node ./scripts/write-assetsignore.mjs",
+    "check:skills": "node --import tsx ./scripts/check-registry-skills.mjs",
     "digests": "node --import tsx ./scripts/precompute-agent-skills-digests.mjs",
     "preview": "astro preview",
     "astro": "astro",
@@ -18,7 +19,7 @@
     "typecheck": "astro check",
     "test": "node --import tsx --test tests/*.test.ts",
     "smoke": "node tests/smoke.mjs",
-    "check": "npm run typecheck && npm test && npm run build && npm run smoke"
+    "check": "npm run typecheck && npm run check:skills && npm test && npm run build && npm run smoke"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^12.6.13",

--- a/scripts/check-registry-skills.mjs
+++ b/scripts/check-registry-skills.mjs
@@ -1,0 +1,117 @@
+/**
+ * Verify registry skill sources are reachable and report digest gaps.
+ * Read-only — does not write agent-skills-digests.json.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { registry } from "../src/data/registry.ts";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const DIGESTS_PATH = join(ROOT, "src/data/agent-skills-digests.json");
+const CONCURRENCY = 12;
+const FETCH_TIMEOUT_MS = 8_000;
+
+const readLocalSkill = (slug) => {
+  const path = join(ROOT, "skills", slug, "SKILL.md");
+  if (!existsSync(path)) return null;
+  return readFileSync(path, "utf8");
+};
+
+const fetchRemote = async (rawUrl) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(rawUrl, {
+      signal: controller.signal,
+      headers: { Accept: "text/plain" },
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return await response.text();
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const loadContent = async (entry) => {
+  if (entry.user.toLowerCase() === "ibelick" && entry.repo === "ui-skills") {
+    const local = readLocalSkill(entry.slug);
+    if (local) return local;
+  }
+  return fetchRemote(entry.rawUrl);
+};
+
+async function mapPool(items, concurrency, mapper) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        results[index] = await mapper(items[index], index);
+      }
+    }),
+  );
+  return results;
+}
+
+const readDigests = () => {
+  if (!existsSync(DIGESTS_PATH)) {
+    return new Set();
+  }
+  try {
+    const payload = JSON.parse(readFileSync(DIGESTS_PATH, "utf8"));
+    return new Set(Object.keys(payload.digests ?? {}));
+  } catch {
+    return new Set();
+  }
+};
+
+const results = await mapPool(registry, CONCURRENCY, async (entry) => {
+  try {
+    const content = await loadContent(entry);
+    if (!content.trim()) {
+      return { entry, ok: false, error: "empty content" };
+    }
+    return { entry, ok: true };
+  } catch (error) {
+    return {
+      entry,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+});
+
+const failed = results.filter((result) => !result.ok);
+const digestSlugs = readDigests();
+const missingDigests = registry.filter((entry) => !digestSlugs.has(entry.pathSlug));
+
+console.log(
+  `[check:skills] registry=${registry.length} ok=${registry.length - failed.length} failed=${failed.length} missingDigests=${missingDigests.length}`,
+);
+
+for (const result of failed) {
+  console.log(
+    `[check:skills] FAIL ${result.entry.pathSlug}: ${result.error}\n  ${result.entry.rawUrl}`,
+  );
+}
+
+for (const entry of missingDigests) {
+  const alsoFailed = failed.some(
+    (result) => result.entry.pathSlug === entry.pathSlug,
+  );
+  if (!alsoFailed) {
+    console.log(
+      `[check:skills] WARN missing digest ${entry.pathSlug}\n  ${entry.rawUrl}`,
+    );
+  }
+}
+
+if (failed.length > 0) {
+  process.exitCode = 1;
+}

--- a/src/data/agent-skills-digests.json
+++ b/src/data/agent-skills-digests.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-08-13T18:21:35.996Z",
-  "skillCount": 199,
+  "generatedAt": "2026-08-13T18:27:30.835Z",
+  "skillCount": 209,
   "digests": {
     "ibelick/ui-skills-root": "sha256:d4e1033f910467164a9cd3931277c1b309cb87c6d23cb5f184a65bfdf92b1c9c",
     "ibelick/baseline-ui": "sha256:fea3322f36d58fdafafce2aef56e4556dd2ac7b20876b7dff7d8be7f25fa597f",
@@ -200,6 +200,16 @@
     "redongreen/create-voice": "sha256:c1a1a48717bb28ca06f9f00ee0aa1803e10a448d37b80c72526fe3adca200c09",
     "nvillapiano/cc-figma-tokens": "sha256:2044e6207414700ca4d33c7b8651bdff8dae2ab170a877c2c29e16691eeb673d",
     "oso95/scroll-world": "sha256:e56fe396c1fa258278289cfa9cbf17253519f11f4856535f7709dd2368e3e65e",
-    "iannuttall/seo": "sha256:371405668b939697d58f83baf070488292690a81bb966129acd138a53d613462"
+    "iannuttall/seo": "sha256:371405668b939697d58f83baf070488292690a81bb966129acd138a53d613462",
+    "remotion-dev/remotion-best-practices": "sha256:db7d6b0e052d2ed4327957c6d6181347c89bb99bc4d788ff2b3e47f21d30de65",
+    "vercel/next-cache-components": "sha256:e0571079c1c8af832df28849a6087a71aa415af2f561a4d83ea4a2a477744baa",
+    "vercel/next-cache-components-optimizer": "sha256:9b538b7f58241f8d6d808a35967bd8b0624f3ae97f7904ab51b294b05e533210",
+    "accesslint/audit-and-fix": "sha256:fa1f1af1f043a075a93e989b35d00e74c1539cfe840dd69b70c4a00625eb9e44",
+    "accesslint/contrast-checker": "sha256:3a3ac56289191371509130a83f3b86152174c8464ad2464e0d9b49c7d2e86b94",
+    "accesslint/refactor": "sha256:93a6cb8508bd555629ad1d23ff7aa8ccf1154da750a61503c3940716ce7f4b64",
+    "accesslint/link-purpose": "sha256:3a3ac56289191371509130a83f3b86152174c8464ad2464e0d9b49c7d2e86b94",
+    "accesslint/use-of-color": "sha256:3a3ac56289191371509130a83f3b86152174c8464ad2464e0d9b49c7d2e86b94",
+    "mattpocock/to-issues": "sha256:5ecdf1d4df8a360ed39df21a2347f97ba177afd449a577da4f6b6ea8e1ebb808",
+    "mattpocock/to-prd": "sha256:5d26479544b08048d3a8f79d937b39bc613a617f026b3fd083bafc1e99a7b811"
   }
 }

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -115,149 +115,6 @@ const registrySource: RegistrySourceSkill[] = [
       "Use when you want to turn a product goal into a design-first UI prompt with clear layout, type, color, and constraint choices.",
   },
   {
-    slug: "design-taste-frontend",
-    user: "MengTo",
-    repo: "Skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/MengTo/Skills/main/agent-skills/ui/design-taste-frontend/SKILL.md",
-    githubUrl:
-      "https://github.com/MengTo/Skills/blob/main/agent-skills/ui/design-taste-frontend/SKILL.md",
-    name: "design-taste-frontend",
-    topics: ["visual", "taste", "systems"],
-    description:
-      "Use when the UI needs stronger taste, restraint, hierarchy, and visual coherence without changing the product shape.",
-  },
-  {
-    slug: "full-output-enforcement",
-    user: "MengTo",
-    repo: "Skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/MengTo/Skills/main/agent-skills/ui/full-output-enforcement/SKILL.md",
-    githubUrl:
-      "https://github.com/MengTo/Skills/blob/main/agent-skills/ui/full-output-enforcement/SKILL.md",
-    name: "full-output-enforcement",
-    topics: ["systems", "tooling", "frontend"],
-    description:
-      "Use when you need the agent to deliver the complete requested output instead of a partial or truncated result.",
-  },
-  {
-    slug: "gpt-taste",
-    user: "MengTo",
-    repo: "Skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/MengTo/Skills/main/agent-skills/ui/gpt-taste/SKILL.md",
-    githubUrl:
-      "https://github.com/MengTo/Skills/blob/main/agent-skills/ui/gpt-taste/SKILL.md",
-    name: "gpt-taste",
-    topics: ["taste", "visual", "frontend"],
-    description:
-      "Use when you want stronger aesthetic judgment, visual refinement, and better-looking interface decisions from the model.",
-  },
-  {
-    slug: "high-end-visual-design",
-    user: "MengTo",
-    repo: "Skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/MengTo/Skills/main/agent-skills/ui/high-end-visual-design/SKILL.md",
-    githubUrl:
-      "https://github.com/MengTo/Skills/blob/main/agent-skills/ui/high-end-visual-design/SKILL.md",
-    name: "high-end-visual-design",
-    topics: ["visual", "systems", "craft"],
-    description:
-      "Use when the interface needs a premium, high-polish visual treatment with disciplined spacing and hierarchy.",
-  },
-  {
-    slug: "image-to-code",
-    user: "MengTo",
-    repo: "Skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/MengTo/Skills/main/agent-skills/ui/image-to-code/SKILL.md",
-    githubUrl:
-      "https://github.com/MengTo/Skills/blob/main/agent-skills/ui/image-to-code/SKILL.md",
-    name: "image-to-code",
-    topics: ["frontend", "visual", "tooling"],
-    description:
-      "Use when you have a visual reference and want a practical workflow to translate it into implementation details.",
-  },
-  {
-    slug: "industrial-brutalist-ui",
-    user: "MengTo",
-    repo: "Skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/MengTo/Skills/main/agent-skills/ui/industrial-brutalist-ui/SKILL.md",
-    githubUrl:
-      "https://github.com/MengTo/Skills/blob/main/agent-skills/ui/industrial-brutalist-ui/SKILL.md",
-    name: "industrial-brutalist-ui",
-    topics: ["visual", "systems", "craft"],
-    description:
-      "Use when you want a harder-edged, brutalist UI direction with strong structure and visual tension.",
-  },
-  {
-    slug: "minimalist-ui",
-    user: "MengTo",
-    repo: "Skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/MengTo/Skills/main/agent-skills/ui/minimalist-ui/SKILL.md",
-    githubUrl:
-      "https://github.com/MengTo/Skills/blob/main/agent-skills/ui/minimalist-ui/SKILL.md",
-    name: "minimalist-ui",
-    topics: ["visual", "systems", "craft"],
-    description:
-      "Use when you want a restrained UI direction with fewer elements, cleaner hierarchy, and more negative space.",
-  },
-  {
-    slug: "redesign-existing-projects",
-    user: "MengTo",
-    repo: "Skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/MengTo/Skills/main/agent-skills/ui/redesign-existing-projects/SKILL.md",
-    githubUrl:
-      "https://github.com/MengTo/Skills/blob/main/agent-skills/ui/redesign-existing-projects/SKILL.md",
-    name: "redesign-existing-projects",
-    topics: ["visual", "frontend", "systems"],
-    description:
-      "Use when you need to improve an existing product interface without throwing away the underlying product structure.",
-  },
-  {
-    slug: "seo-audit",
-    user: "MengTo",
-    repo: "Skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/MengTo/Skills/main/agent-skills/ui/seo-audit/SKILL.md",
-    githubUrl:
-      "https://github.com/MengTo/Skills/blob/main/agent-skills/ui/seo-audit/SKILL.md",
-    name: "seo-audit",
-    topics: ["frontend", "architecture", "tooling"],
-    description:
-      "Use when you need to review a page for metadata, headings, structured data, and search visibility basics.",
-  },
-  {
-    slug: "stitch-design-taste",
-    user: "MengTo",
-    repo: "Skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/MengTo/Skills/main/agent-skills/ui/stitch-design-taste/SKILL.md",
-    githubUrl:
-      "https://github.com/MengTo/Skills/blob/main/agent-skills/ui/stitch-design-taste/SKILL.md",
-    name: "stitch-design-taste",
-    topics: ["visual", "taste", "systems"],
-    description:
-      "Use when you want to combine multiple references into one coherent visual direction without losing consistency.",
-  },
-  {
-    slug: "swiftui-pro",
-    user: "MengTo",
-    repo: "Skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/MengTo/Skills/main/agent-skills/ui/swiftui-pro/SKILL.md",
-    githubUrl:
-      "https://github.com/MengTo/Skills/blob/main/agent-skills/ui/swiftui-pro/SKILL.md",
-    name: "swiftui-pro",
-    topics: ["swiftui", "frontend", "systems"],
-    description:
-      "Use when building or polishing SwiftUI interfaces with production-minded composition and layout discipline.",
-  },
-  {
     slug: "landing-page",
     user: "MengTo",
     repo: "Skills",
@@ -535,9 +392,9 @@ const registrySource: RegistrySourceSkill[] = [
     user: "remotion-dev",
     repo: "skills",
     rawUrl:
-      "https://raw.githubusercontent.com/remotion-dev/skills/main/skills/remotion/SKILL.md",
+      "https://raw.githubusercontent.com/remotion-dev/skills/main/skills/remotion-best-practices/SKILL.md",
     githubUrl:
-      "https://github.com/remotion-dev/skills/blob/main/skills/remotion/SKILL.md",
+      "https://github.com/remotion-dev/skills/blob/main/skills/remotion-best-practices/SKILL.md",
     name: "remotion-best-practices",
     topics: ["video", "motion", "remotion"],
     description:
@@ -661,43 +518,30 @@ const registrySource: RegistrySourceSkill[] = [
       "Review UI code for Web Interface Guidelines compliance. Audit design, accessibility, and UX against Vercel's best practices.",
   },
   {
-    slug: "next-best-practices",
-    user: "vercel-labs",
-    repo: "next-skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/vercel-labs/next-skills/main/skills/next-best-practices/SKILL.md",
-    githubUrl:
-      "https://github.com/vercel-labs/next-skills/blob/main/skills/next-best-practices/SKILL.md",
-    name: "next-best-practices",
-    topics: ["nextjs", "frontend", "performance"],
-    description:
-      "Next.js best practices: file conventions, RSC boundaries, data patterns, async APIs, metadata, error handling, and optimization.",
-  },
-  {
     slug: "next-cache-components",
-    user: "vercel-labs",
-    repo: "next-skills",
+    user: "vercel",
+    repo: "next.js",
     rawUrl:
-      "https://raw.githubusercontent.com/vercel-labs/next-skills/main/skills/next-cache-components/SKILL.md",
+      "https://raw.githubusercontent.com/vercel/next.js/canary/skills/next-cache-components-adoption/SKILL.md",
     githubUrl:
-      "https://github.com/vercel-labs/next-skills/blob/main/skills/next-cache-components/SKILL.md",
+      "https://github.com/vercel/next.js/blob/canary/skills/next-cache-components-adoption/SKILL.md",
     name: "next-cache-components",
     topics: ["nextjs", "performance", "frontend"],
     description:
-      "Next.js 16 Cache Components guidance covering PPR, use cache directive, cacheLife, cacheTag, and updateTag.",
+      "Enable Cache Components in a Next.js app and resolve blocking routes surfaced during adoption.",
   },
   {
-    slug: "next-upgrade",
-    user: "vercel-labs",
-    repo: "next-skills",
+    slug: "next-cache-components-optimizer",
+    user: "vercel",
+    repo: "next.js",
     rawUrl:
-      "https://raw.githubusercontent.com/vercel-labs/next-skills/main/skills/next-upgrade/SKILL.md",
+      "https://raw.githubusercontent.com/vercel/next.js/canary/skills/next-cache-components-optimizer/SKILL.md",
     githubUrl:
-      "https://github.com/vercel-labs/next-skills/blob/main/skills/next-upgrade/SKILL.md",
-    name: "next-upgrade",
-    topics: ["nextjs", "tooling", "frontend"],
+      "https://github.com/vercel/next.js/blob/canary/skills/next-cache-components-optimizer/SKILL.md",
+    name: "next-cache-components-optimizer",
+    topics: ["nextjs", "performance", "testing"],
     description:
-      "Upgrade Next.js to the latest version using official migration guides and codemods.",
+      "Drive a Next.js route to instant navigation under Cache Components using a failing Playwright test and an agentic fix loop.",
   },
   {
     slug: "agent-browser",
@@ -1413,9 +1257,9 @@ const registrySource: RegistrySourceSkill[] = [
     user: "AccessLint",
     repo: "claude-marketplace",
     rawUrl:
-      "https://raw.githubusercontent.com/AccessLint/claude-marketplace/main/plugins/accesslint/skills/audit-and-fix/SKILL.md",
+      "https://raw.githubusercontent.com/AccessLint/claude-marketplace/main/plugins/accesslint/skills/accessibility-audit/SKILL.md",
     githubUrl:
-      "https://github.com/AccessLint/claude-marketplace/blob/main/plugins/accesslint/skills/audit-and-fix/SKILL.md",
+      "https://github.com/AccessLint/claude-marketplace/blob/main/plugins/accesslint/skills/accessibility-audit/SKILL.md",
     name: "audit-and-fix",
     topics: ["accessibility", "testing", "frontend"],
     description:
@@ -1426,9 +1270,9 @@ const registrySource: RegistrySourceSkill[] = [
     user: "AccessLint",
     repo: "claude-marketplace",
     rawUrl:
-      "https://raw.githubusercontent.com/AccessLint/claude-marketplace/main/plugins/accesslint/skills/audit-and-fix/SKILL.md",
+      "https://raw.githubusercontent.com/AccessLint/claude-marketplace/main/plugins/accesslint/skills/accessibility-inspect/SKILL.md",
     githubUrl:
-      "https://github.com/AccessLint/claude-marketplace/blob/main/plugins/accesslint/skills/audit-and-fix/SKILL.md",
+      "https://github.com/AccessLint/claude-marketplace/blob/main/plugins/accesslint/skills/accessibility-inspect/SKILL.md",
     name: "contrast-checker",
     topics: ["accessibility", "testing", "color"],
     description:
@@ -1439,9 +1283,9 @@ const registrySource: RegistrySourceSkill[] = [
     user: "AccessLint",
     repo: "claude-marketplace",
     rawUrl:
-      "https://raw.githubusercontent.com/AccessLint/claude-marketplace/main/plugins/accesslint/skills/audit-and-fix/SKILL.md",
+      "https://raw.githubusercontent.com/AccessLint/claude-marketplace/main/plugins/accesslint/skills/accessibility-inspect/SKILL.md",
     githubUrl:
-      "https://github.com/AccessLint/claude-marketplace/blob/main/plugins/accesslint/skills/audit-and-fix/SKILL.md",
+      "https://github.com/AccessLint/claude-marketplace/blob/main/plugins/accesslint/skills/accessibility-inspect/SKILL.md",
     name: "link-purpose",
     topics: ["accessibility", "testing", "interaction"],
     description:
@@ -1452,9 +1296,9 @@ const registrySource: RegistrySourceSkill[] = [
     user: "AccessLint",
     repo: "claude-marketplace",
     rawUrl:
-      "https://raw.githubusercontent.com/AccessLint/claude-marketplace/main/plugins/accesslint/skills/audit-and-fix/SKILL.md",
+      "https://raw.githubusercontent.com/AccessLint/claude-marketplace/main/plugins/accesslint/skills/accessibility-fix/SKILL.md",
     githubUrl:
-      "https://github.com/AccessLint/claude-marketplace/blob/main/plugins/accesslint/skills/audit-and-fix/SKILL.md",
+      "https://github.com/AccessLint/claude-marketplace/blob/main/plugins/accesslint/skills/accessibility-fix/SKILL.md",
     name: "refactor",
     topics: ["accessibility", "testing", "frontend"],
     description:
@@ -1465,9 +1309,9 @@ const registrySource: RegistrySourceSkill[] = [
     user: "AccessLint",
     repo: "claude-marketplace",
     rawUrl:
-      "https://raw.githubusercontent.com/AccessLint/claude-marketplace/main/plugins/accesslint/skills/audit-and-fix/SKILL.md",
+      "https://raw.githubusercontent.com/AccessLint/claude-marketplace/main/plugins/accesslint/skills/accessibility-inspect/SKILL.md",
     githubUrl:
-      "https://github.com/AccessLint/claude-marketplace/blob/main/plugins/accesslint/skills/audit-and-fix/SKILL.md",
+      "https://github.com/AccessLint/claude-marketplace/blob/main/plugins/accesslint/skills/accessibility-inspect/SKILL.md",
     name: "use-of-color",
     topics: ["accessibility", "color", "testing"],
     description:
@@ -2178,9 +2022,9 @@ const registrySource: RegistrySourceSkill[] = [
     user: "mattpocock",
     repo: "skills",
     rawUrl:
-      "https://raw.githubusercontent.com/mattpocock/skills/main/skills/engineering/to-issues/SKILL.md",
+      "https://raw.githubusercontent.com/mattpocock/skills/main/skills/engineering/to-tickets/SKILL.md",
     githubUrl:
-      "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md",
+      "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-tickets/SKILL.md",
     name: "to-issues",
     topics: ["architecture", "tooling", "testing"],
     description: "Breaks a plan or PRD into independently actionable issues.",
@@ -2190,9 +2034,9 @@ const registrySource: RegistrySourceSkill[] = [
     user: "mattpocock",
     repo: "skills",
     rawUrl:
-      "https://raw.githubusercontent.com/mattpocock/skills/main/skills/engineering/to-prd/SKILL.md",
+      "https://raw.githubusercontent.com/mattpocock/skills/main/skills/engineering/to-spec/SKILL.md",
     githubUrl:
-      "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md",
+      "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-spec/SKILL.md",
     name: "to-prd",
     topics: ["architecture", "tooling", "frontend"],
     description:
@@ -2494,32 +2338,6 @@ const registrySource: RegistrySourceSkill[] = [
     topics: ["motion", "frontend", "tooling"],
     description:
       "Lottie and dotLottie integration guidance for playback control, interactivity, runtime theming, and cross-platform export workflows.",
-  },
-  {
-    slug: "conductor-rewrite-performance",
-    user: "brotzky",
-    repo: "performance-skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/brotzky/performance-skills/main/performance/skills/conductor-rewrite-performance/SKILL.md",
-    githubUrl:
-      "https://github.com/brotzky/performance-skills/blob/main/performance/skills/conductor-rewrite-performance/SKILL.md",
-    name: "conductor-rewrite-performance",
-    topics: ["performance", "frontend", "debugging"],
-    description:
-      "Performance guidance for local-first desktop apps, including React render optimization, streaming list virtualization, profiling, and background work.",
-  },
-  {
-    slug: "linear-local-first-architecture",
-    user: "brotzky",
-    repo: "performance-skills",
-    rawUrl:
-      "https://raw.githubusercontent.com/brotzky/performance-skills/main/performance/skills/linear-local-first-architecture/SKILL.md",
-    githubUrl:
-      "https://github.com/brotzky/performance-skills/blob/main/performance/skills/linear-local-first-architecture/SKILL.md",
-    name: "linear-local-first-architecture",
-    topics: ["performance", "architecture", "frontend"],
-    description:
-      "Local-first architecture guidance for instant-feeling web apps, optimistic updates, bundle loading, offline behavior, and responsive UI motion.",
   },
   {
     slug: "gc-minimal-zine-poster-v0-1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

24 registry skills were failing to load (HTTP 404), so they were missing from the discovery index and `/skills/...` pages would error.

## Solution

- Added `npm run check:skills` to verify every registry `rawUrl` is reachable and report digest gaps
- Wired it into `npm run check`
- Fixed or removed broken entries:
  - **Removed** 11 deleted MengTo UI skills and 2 brotzky skills whose repos are gone
  - **Removed** deprecated `next-best-practices` and `next-upgrade` (moved into Next.js bundled docs)
  - **Updated** Remotion, AccessLint, Matt Pocock, and Next.js cache component URLs to their current locations
  - **Added** `next-cache-components-optimizer`
- Refreshed digests — all **209** skills now load successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c016555-381f-4d29-af1c-a31fa95fbb6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c016555-381f-4d29-af1c-a31fa95fbb6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

