### PR TITLE
Add check:new-skills script for weekly publisher audits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,11 @@
 - Fill `slug`, `user`, `repo`, `rawUrl`, `githubUrl`, `name`, `description`, and `topics`.
 - If a new topic is needed, update `TopicSlug`, `topicsBySlug`, `relatedTopicSlugs`, and `primaryDesignTopicSlugs` only when it is a core topic.
 - Do not add local `skills/*` files unless the repo actually hosts the skill markdown.
+
+## Weekly new skills audit
+
+1. Run `npm run check:new-skills` (set `GITHUB_TOKEN` or `GH_TOKEN` for GitHub API rate limits).
+2. Review the markdown table, or use `--json` for machine-readable output and `--all` to include large monorepo counts.
+3. Curate skills that fit ui-skills: design engineering, UI craft, motion, accessibility, color, typography, and related frontend work. Skip general dev tooling, framework migrations, and native-only skills unless they are core to the registry.
+4. Add approved skills to `registrySource` in `src/data/registry.ts`.
+5. Run `npm run digests` and `npm run check:skills` before opening a PR.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "astro build",
     "postbuild": "node ./scripts/write-assetsignore.mjs",
     "check:skills": "node --import tsx ./scripts/check-registry-skills.mjs",
+    "check:new-skills": "node --import tsx ./scripts/check-new-skills.mjs",
     "digests": "node --import tsx ./scripts/precompute-agent-skills-digests.mjs",
     "check:digests": "node --import tsx ./scripts/check-agent-skills-digests.mjs",
     "preview": "astro preview",

--- a/scripts/check-new-skills.mjs
+++ b/scripts/check-new-skills.mjs
@@ -6,6 +6,10 @@
  *   npm run check:new-skills -- --json
  *   npm run check:new-skills -- --all
  *
+ * Workflow: run this weekly, review output, curate skills that fit ui-skills
+ * (design, UI, motion, accessibility, craft), add to registry.ts, then run
+ * `npm run digests` and `npm run check:skills`.
+ *
  * Env:
  *   GITHUB_TOKEN or GH_TOKEN — recommended for higher GitHub API limits.
  */
@@ -38,36 +42,15 @@ for (const skill of registry) {
   });
 }
 
-const FOCUS_REPOS = new Set([
-  "jakubkrehel/skills",
-  "emilkowalski/skills",
-  "antfu/skills",
-  "millionco/skills",
-  "kitlangton/skills",
-  "remotion-dev/skills",
-  "iart-ai/web-animation-skills",
-  "Leonxlnx/taste-skill",
-  "PrototyperAI/prototyper-ui",
-  "Jakubantalik/transitions.dev",
-  "addyosmani/web-quality-skills",
-  "nextlevelbuilder/ui-ux-pro-max-skill",
-  "saadeghi/daisyui",
-  "remix-run/agent-skills",
-  "redongreen/uSpec",
-  "mrstev3n/balise-skills",
-  "CaliCastle/skills",
-  "edenspiekermann/Skills",
-  "figma/mcp-server-guide",
-  "greensock/gsap-skills",
-  "ericzakariasson/scandinavian-design",
-  "flornkm/skills",
-  "openai/skills",
-  "Superfuture/design-review",
-  "petergyang/human-review",
-  "pbakaus/impeccable",
-  "dimillian/skills",
-  "callstackincubator/agent-skills",
-  "vercel-labs/agent-skills",
+const MONOREPO_REPOS = new Set([
+  "wshobson/agents",
+  "MengTo/Skills",
+  "cursor/plugins",
+  "anthropics/skills",
+  "bencium/bencium-marketplace",
+  "millionco/react-doctor",
+  "addyosmani/agent-skills",
+  "vercel-labs/agent-browser",
 ]);
 const AGENT_FOLDERS = new Set([
   "skills",
@@ -123,7 +106,7 @@ function isKnownSkill(user, repo, slug, rawUrl) {
 }
 
 function isFocusRepo(user, repo) {
-  return FOCUS_REPOS.has(`${user}/${repo}`);
+  return !MONOREPO_REPOS.has(`${user}/${repo}`);
 }
 
 function dedupeSkills(skills) {

--- a/scripts/check-new-skills.mjs
+++ b/scripts/check-new-skills.mjs
@@ -1,0 +1,305 @@
+/**
+ * Find SKILL.md files in indexed publisher repos that are not yet in registry.
+ *
+ * Usage:
+ *   npm run check:new-skills
+ *   npm run check:new-skills -- --json
+ *   npm run check:new-skills -- --all
+ *
+ * Env:
+ *   GITHUB_TOKEN or GH_TOKEN — recommended for higher GitHub API limits.
+ */
+import { registry } from "../src/data/registry.ts";
+
+const GITHUB_API = "https://api.github.com";
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+const args = new Set(process.argv.slice(2));
+const jsonOutput = args.has("--json");
+const includeMonorepos = args.has("--all");
+
+const knownRawUrls = new Set(
+  registry.map((skill) => normalizeRawUrl(skill.rawUrl)),
+);
+const knownSlugsByRepo = new Map();
+
+for (const skill of registry) {
+  const repoKey = `${skill.user}/${skill.repo}`;
+  if (!knownSlugsByRepo.has(repoKey)) {
+    knownSlugsByRepo.set(repoKey, new Set());
+  }
+  knownSlugsByRepo.get(repoKey).add(skill.slug);
+}
+
+const indexedRepos = new Map();
+for (const skill of registry) {
+  indexedRepos.set(`${skill.user}/${skill.repo}`, {
+    user: skill.user,
+    repo: skill.repo,
+  });
+}
+
+const FOCUS_REPOS = new Set([
+  "jakubkrehel/skills",
+  "emilkowalski/skills",
+  "antfu/skills",
+  "millionco/skills",
+  "kitlangton/skills",
+  "remotion-dev/skills",
+  "iart-ai/web-animation-skills",
+  "Leonxlnx/taste-skill",
+  "PrototyperAI/prototyper-ui",
+  "Jakubantalik/transitions.dev",
+  "addyosmani/web-quality-skills",
+  "nextlevelbuilder/ui-ux-pro-max-skill",
+  "saadeghi/daisyui",
+  "remix-run/agent-skills",
+  "redongreen/uSpec",
+  "mrstev3n/balise-skills",
+  "CaliCastle/skills",
+  "edenspiekermann/Skills",
+  "figma/mcp-server-guide",
+  "greensock/gsap-skills",
+  "ericzakariasson/scandinavian-design",
+  "flornkm/skills",
+  "openai/skills",
+  "Superfuture/design-review",
+  "petergyang/human-review",
+  "pbakaus/impeccable",
+  "dimillian/skills",
+  "callstackincubator/agent-skills",
+  "vercel-labs/agent-skills",
+]);
+const AGENT_FOLDERS = new Set([
+  "skills",
+  ".claude",
+  ".cursor",
+  ".codex",
+  ".agents",
+  ".agent",
+  ".gemini",
+  ".github",
+  ".grok",
+  ".hermes",
+  ".kiro",
+  ".opencode",
+  ".pi",
+  ".qoder",
+  ".rovodev",
+  ".trae-cn",
+  ".trae",
+  ".vibe",
+  "plugin",
+]);
+
+function normalizeRawUrl(url) {
+  return url.toLowerCase();
+}
+
+function skillSlugFromPath(path) {
+  const parts = path.split("/");
+  const idx = parts.lastIndexOf("SKILL.md");
+  if (idx <= 0) return parts.at(-2) ?? "unknown";
+  const parent = parts[idx - 1];
+  if (parent && !AGENT_FOLDERS.has(parent)) {
+    return parent;
+  }
+  return parts[idx - 1]?.replace(/\.md$/i, "") ?? "unknown";
+}
+
+function pathScore(path) {
+  if (path.includes("/skills/")) return 0;
+  if (path.includes("/plugin/skills/")) return 1;
+  return 2;
+}
+
+function buildRawUrl(user, repo, branch, path) {
+  return `https://raw.githubusercontent.com/${user}/${repo}/${branch}/${path}`;
+}
+
+function isKnownSkill(user, repo, slug, rawUrl) {
+  if (knownRawUrls.has(normalizeRawUrl(rawUrl))) return true;
+  const repoSlugs = knownSlugsByRepo.get(`${user}/${repo}`);
+  return repoSlugs?.has(slug) ?? false;
+}
+
+function isFocusRepo(user, repo) {
+  return FOCUS_REPOS.has(`${user}/${repo}`);
+}
+
+function dedupeSkills(skills) {
+  const map = new Map();
+  for (const skill of skills) {
+    const key = `${skill.user}/${skill.repo}/${skill.slug}`;
+    const existing = map.get(key);
+    if (!existing || pathScore(skill.path) < pathScore(existing.path)) {
+      map.set(key, skill);
+    }
+  }
+  return [...map.values()];
+}
+
+async function githubFetch(path) {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "ui-skills-check-new-skills",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const response = await fetch(`${GITHUB_API}${path}`, { headers });
+  if (!response.ok) {
+    return { ok: false, status: response.status, data: null };
+  }
+  return { ok: true, status: response.status, data: await response.json() };
+}
+
+async function listSkillPaths(user, repo, defaultBranch = "main") {
+  for (const branch of [defaultBranch, "main", "master"]) {
+    const result = await githubFetch(
+      `/repos/${encodeURIComponent(user)}/${encodeURIComponent(repo)}/git/trees/${encodeURIComponent(branch)}?recursive=1`,
+    );
+    if (!result.ok) continue;
+
+    const paths = result.data.tree
+      .filter(
+        (item) => item.type === "blob" && /(^|\/)SKILL\.md$/i.test(item.path),
+      )
+      .map((item) => item.path);
+
+    if (paths.length > 0) {
+      return { branch, paths };
+    }
+  }
+
+  return { branch: defaultBranch, paths: [] };
+}
+
+async function scanRepo(user, repo, defaultBranch) {
+  const { branch, paths } = await listSkillPaths(user, repo, defaultBranch);
+  const newSkills = [];
+
+  for (const path of paths) {
+    const slug = skillSlugFromPath(path);
+    const rawUrl = normalizeRawUrl(buildRawUrl(user, repo, branch, path));
+    if (isKnownSkill(user, repo, slug, rawUrl)) continue;
+
+    newSkills.push({
+      user,
+      repo,
+      slug,
+      path,
+      rawUrl,
+      githubUrl: `https://github.com/${user}/${repo}/blob/${branch}/${path}`,
+      focus: isFocusRepo(user, repo),
+    });
+  }
+
+  return newSkills;
+}
+
+function groupByUserRepo(skills) {
+  const groups = new Map();
+  for (const skill of skills) {
+    const key = `${skill.user}/${skill.repo}`;
+    if (!groups.has(key)) {
+      groups.set(key, {
+        user: skill.user,
+        repo: skill.repo,
+        focus: skill.focus,
+        skills: [],
+      });
+    }
+    groups.get(key).skills.push(skill);
+  }
+  return [...groups.values()].sort((a, b) => {
+    if (a.focus !== b.focus) return a.focus ? -1 : 1;
+    return `${a.user}/${a.repo}`.localeCompare(`${b.user}/${b.repo}`);
+  });
+}
+
+function toMarkdown(focusSkills, monorepoGroups) {
+  const lines = [
+    "# New skills in indexed publisher repos",
+    "",
+    `Generated: ${new Date().toISOString()}`,
+    "",
+    "## Skill-focused repos",
+    "",
+    "| User | Skill | Repo |",
+    "| --- | --- | --- |",
+  ];
+
+  for (const skill of focusSkills.sort((a, b) =>
+    `${a.user}/${a.slug}`.localeCompare(`${b.user}/${b.slug}`),
+  )) {
+    lines.push(
+      `| ${skill.user} | ${skill.slug} | [${skill.repo}](https://github.com/${skill.user}/${skill.repo}) |`,
+    );
+  }
+
+  if (monorepoGroups.length > 0) {
+    lines.push("", "## Large monorepos (not listed individually)", "", "| User | Repo | New skills |", "| --- | --- | --- |");
+    for (const group of monorepoGroups) {
+      lines.push(
+        `| ${group.user} | [${group.repo}](https://github.com/${group.user}/${group.repo}) | ${group.skills.length} |`,
+      );
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+const allNewSkills = [];
+
+console.error(`[check:new-skills] scanning ${indexedRepos.size} indexed repos...`);
+
+for (const { user, repo } of indexedRepos.values()) {
+  const meta = await githubFetch(
+    `/repos/${encodeURIComponent(user)}/${encodeURIComponent(repo)}`,
+  );
+  const defaultBranch = meta.ok ? meta.data.default_branch : "main";
+  const found = await scanRepo(user, repo, defaultBranch);
+  allNewSkills.push(...found);
+  if (found.length > 0) {
+    console.error(`[check:new-skills] + ${user}/${repo}: ${found.length}`);
+  }
+}
+
+const deduped = dedupeSkills(allNewSkills);
+const groups = groupByUserRepo(deduped);
+const focusSkills = deduped.filter((skill) => skill.focus);
+const monorepoGroups = groups.filter((group) => !group.focus);
+
+const summary = {
+  indexedRepos: indexedRepos.size,
+  registrySkills: registry.length,
+  newSkills: deduped.length,
+  focusSkills: focusSkills.length,
+  monorepoSkills: deduped.length - focusSkills.length,
+  usersWithNewSkills: new Set(deduped.map((skill) => skill.user)).size,
+};
+
+console.error(
+  `[check:new-skills] ${summary.newSkills} new (${summary.focusSkills} focused, ${summary.monorepoSkills} monorepo) across ${summary.usersWithNewSkills} users`,
+);
+
+if (jsonOutput) {
+  console.log(
+    JSON.stringify(
+      {
+        summary,
+        focus: focusSkills,
+        monorepos: monorepoGroups.map((group) => ({
+          user: group.user,
+          repo: group.repo,
+          count: group.skills.length,
+          slugs: group.skills.map((skill) => skill.slug),
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+} else {
+  const outputGroups = includeMonorepos ? monorepoGroups : [];
+  process.stdout.write(toMarkdown(focusSkills, outputGroups));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `npm run check:new-skills` to scan indexed publisher repos on GitHub and report `SKILL.md` files not yet in the registry.

**Weekly workflow** (documented in AGENTS.md):
1. Run `npm run check:new-skills`
2. Agent reviews output and curates what fits ui-skills
3. Add approved skills to `registry.ts`
4. Run `npm run digests` and `npm run check:skills`

**Usage**
- `npm run check:new-skills` — markdown table
- `npm run check:new-skills -- --json` — machine-readable output for agents
- `npm run check:new-skills -- --all` — include large monorepo summary

Set `GITHUB_TOKEN` or `GH_TOKEN` for higher API rate limits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c016555-381f-4d29-af1c-a31fa95fbb6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c016555-381f-4d29-af1c-a31fa95fbb6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

