### PR TITLE
Add Mesurer link to footer

### DIFF
--- a/src/ui/footer.astro
+++ b/src/ui/footer.astro
@@ -115,6 +115,11 @@ const footerSections: FooterSection[] = [
         href: "https://interfaceoffice.com/",
         external: true,
       },
+      {
+        label: "Mesurer",
+        href: "https://mesurer.dev/",
+        external: true,
+      },
     ],
   },
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a link to [mesurer.dev](https://mesurer.dev/) in the footer **More** section, alongside the existing external links.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c016555-381f-4d29-af1c-a31fa95fbb6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c016555-381f-4d29-af1c-a31fa95fbb6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

